### PR TITLE
Fixed destructor and close in HDF5 writers.

### DIFF
--- a/builtins/HDF5DataWriter.cpp
+++ b/builtins/HDF5DataWriter.cpp
@@ -6,9 +6,9 @@
 // Maintainer: 
 // Created: Sat Feb 25 16:03:59 2012 (+0530)
 // Version: 
-// Last-Updated: Wed Nov 14 18:47:02 2012 (+0530)
+// Last-Updated: Sun Dec 20 23:16:02 2015 (-0500)
 //           By: subha
-//     Update #: 735
+//     Update #: 741
 // URL: 
 // Keywords: 
 // Compatibility: 
@@ -122,6 +122,11 @@ HDF5DataWriter::HDF5DataWriter(): flushLimit_(4*1024*1024), steps_(0)
 
 HDF5DataWriter::~HDF5DataWriter()
 {
+    close();
+}
+
+void HDF5DataWriter::close()
+{
     if (filehandle_ < 0){
         return;
     }
@@ -137,7 +142,7 @@ HDF5DataWriter::~HDF5DataWriter()
             }
         }
     }
-    filehandle_ = -1;
+    HDF5WriterBase::close();
 }
 
 void HDF5DataWriter::flush()

--- a/builtins/HDF5DataWriter.h
+++ b/builtins/HDF5DataWriter.h
@@ -6,9 +6,9 @@
 // Maintainer: 
 // Created: Sat Feb 25 15:47:23 2012 (+0530)
 // Version: 
-// Last-Updated: Mon Feb 27 09:58:21 2012 (+0530)
-//           By: Subhasis Ray
-//     Update #: 44
+// Last-Updated: Sun Dec 20 23:17:22 2015 (-0500)
+//           By: subha
+//     Update #: 45
 // URL: 
 // Keywords: 
 // Compatibility: 
@@ -50,6 +50,7 @@ class HDF5DataWriter: public HDF5WriterBase
     void process(const Eref &e, ProcPtr p);
     void reinit(const Eref &e, ProcPtr p);
     virtual void flush();
+    virtual void close();
     static const Cinfo* initCinfo();
   protected:
     unsigned int flushLimit_;

--- a/builtins/HDF5WriterBase.cpp
+++ b/builtins/HDF5WriterBase.cpp
@@ -6,9 +6,9 @@
 // Maintainer: 
 // Created: Sat Feb 25 14:42:03 2012 (+0530)
 // Version: 
-// Last-Updated: Thu Aug 27 01:35:46 2015 (-0400)
+// Last-Updated: Sun Dec 20 23:20:44 2015 (-0500)
 //           By: subha
-//     Update #: 295
+//     Update #: 298
 // URL: 
 // Keywords: 
 // Compatibility: 
@@ -530,15 +530,7 @@ HDF5WriterBase::HDF5WriterBase():
 HDF5WriterBase::~HDF5WriterBase()
 {
     // derived classes should flush data in their own destructors
-    if (filehandle_ < 0){
-        return;
-    }
-    flush();
-    herr_t err = H5Fclose(filehandle_);
-    filehandle_ = -1;
-    if (err < 0){
-        cerr << "Error: Error occurred when closing file. Error code: " << err << endl;
-    }
+    close();
 }
 
 void HDF5WriterBase::setFilename(string filename)

--- a/builtins/NSDFWriter.cpp
+++ b/builtins/NSDFWriter.cpp
@@ -6,9 +6,9 @@
 // Maintainer: 
 // Created: Thu Jun 18 23:16:11 2015 (-0400)
 // Version: 
-// Last-Updated: Sat Aug 29 12:41:00 2015 (-0400)
+// Last-Updated: Sun Dec 20 23:20:19 2015 (-0500)
 //           By: subha
-//     Update #: 38
+//     Update #: 49
 // URL: 
 // Keywords: 
 // Compatibility: 
@@ -155,6 +155,14 @@ NSDFWriter::NSDFWriter(): eventGroup_(-1), uniformGroup_(-1), dataGroup_(-1), mo
 
 NSDFWriter::~NSDFWriter()
 {
+    close();
+}
+
+void NSDFWriter::close()
+{
+    if (filehandle_ < 0){
+        return;
+    }
     flush();
     closeUniformData();
     if (uniformGroup_ >= 0){
@@ -167,6 +175,7 @@ NSDFWriter::~NSDFWriter()
     if (dataGroup_ >= 0){
         H5Gclose(dataGroup_);
     }
+    HDF5DataWriter::close();
 }
 
 void NSDFWriter::closeUniformData()

--- a/builtins/NSDFWriter.h
+++ b/builtins/NSDFWriter.h
@@ -6,9 +6,9 @@
  * Maintainer: 
  * Created: Thu Jun 18 23:06:59 2015 (-0400)
  * Version: 
- * Last-Updated: 
- *           By: 
- *     Update #: 0
+ * Last-Updated: Sun Dec 20 23:17:32 2015 (-0500)
+ *           By: subha
+ *     Update #: 2
  * URL: 
  * Keywords: 
  * Compatibility: 
@@ -93,6 +93,7 @@ class NSDFWriter: public HDF5DataWriter
     void closeUniformData();
     void openEventData(const Eref &eref);
     void closeEventData();
+    virtual void close();
     void createUniformMap();
     void createEventMap();
     void writeModelTree();


### PR DESCRIPTION
This allows clean closure of HDF5 files without deleting the corresponding MOOSE objects.
This is necessary for adding more complex data than are handled within MOOSE. One can close the file at the end of MOOSE simulation and then reopen it using h5py or other HDF5 library in the same script and write more data into it.