### PR TITLE
Reverted change to SbmlWriter class.

### DIFF
--- a/sbml/SbmlWriter.cpp
+++ b/sbml/SbmlWriter.cpp
@@ -715,9 +715,9 @@ string SbmlWriter :: getGroupinfo(Id itr)
 }
 bool SbmlWriter::writeModel( const SBMLDocument* sbmlDoc, const string& filename )
 {
-  // SBMLWriter sbmlWriter;
-  //cout << "sbml writer" << filename << sbmlDoc << endl;
-  bool result = writeSBML( sbmlDoc, filename );
+  SBMLWriter sbmlWriter;
+  // cout << "sbml writer" << filename << sbmlDoc << endl;
+  bool result = writer.writeSBML( sbmlDoc, filename );
   if ( result )
     {
       cout << "Wrote file \"" << filename << "\"" << endl;


### PR DESCRIPTION
There is a confusion between SBMLWriter and SBMLReader classes provided
by libSBML and the same names in MOOSE with CamelCase. This will
definitely cause problem in Windows. Need to either change the names or
use a namespace.