### PR TITLE
Accessing an existing object

### DIFF
--- a/MooseTests.cmake
+++ b/MooseTests.cmake
@@ -135,11 +135,11 @@ set_tests_properties(pymoose-test-calcium-hsolve
     )
 
 # Test accessing existing path without moose.element.
-ADD_TEST( NAME pymoose-access-existing-path
+ADD_TEST( NAME pymoose-test-path
     COMMAND ${TEST_COMMAND} 
-    ${PROJECT_SOURCE_DIR}/tests/python/test_accessing_existing_path.py
+    ${PROJECT_SOURCE_DIR}/tests/python/test_paths.py
     )
-set_tests_properties(pymoose-access-existing-path
+set_tests_properties(pymoose-test-path
     PROPERTIES ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/python"
     )
 

--- a/MooseTests.cmake
+++ b/MooseTests.cmake
@@ -134,6 +134,15 @@ set_tests_properties(pymoose-test-calcium-hsolve
     PROPERTIES ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/python"
     )
 
+# Test accessing existing path without moose.element.
+ADD_TEST( NAME pymoose-access-existing-path
+    COMMAND ${TEST_COMMAND} 
+    ${PROJECT_SOURCE_DIR}/tests/python/test_accessing_existing_path.py
+    )
+set_tests_properties(pymoose-access-existing-path
+    PROPERTIES ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/python"
+    )
+
 # # NOTE: These tests are not enabled yet. They take lot of time. Not all scripts
 # # are fixed yet.
 # # Test moose-examples with very short timeout. 

--- a/pymoose/melement.cpp
+++ b/pymoose/melement.cpp
@@ -67,6 +67,7 @@
 #include "../basecode/Id.h"
 #include "../basecode/ObjId.h"
 #include "../utility/utility.h"
+#include "../utility/print_function.hpp"
 #include "../shell/Shell.h"
 
 #include "moosemodule.h"
@@ -262,7 +263,8 @@ int moose_ObjId_init_from_path(_ObjId * self, PyObject * args,
         if ((basetype != NULL) && PyType_IsSubtype(mytype, basetype))
         {
             // Fine. This path already exits.
-            warn << "Path " << self->oid_.path( ) << "alread exists. Not creating nothing!" << endl;
+            warn << "Path " << self->oid_.path( ) << " already exists. Doing nothing.";
+            moose::showWarn( warn.str( ) );
             return 0;
         }
 #endif

--- a/pymoose/melement.cpp
+++ b/pymoose/melement.cpp
@@ -263,8 +263,10 @@ int moose_ObjId_init_from_path(_ObjId * self, PyObject * args,
         if ((basetype != NULL) && PyType_IsSubtype(mytype, basetype))
         {
             // Fine. This path already exits.
-            warn << "Path " << self->oid_.path( ) << " already exists. Doing nothing.";
-            moose::showWarn( warn.str( ) );
+            err << "Accessing existing paths using object constrcutors has been deprecated. Use "
+                << " moose.element to access existing object. In future "
+                << " this will be an error." << endl;
+            PyErr_WarnEx(PyExc_DeprecationWarning, err.str().c_str(), 1);
             return 0;
         }
 

--- a/pymoose/melement.cpp
+++ b/pymoose/melement.cpp
@@ -230,7 +230,7 @@ int moose_ObjId_init_from_path(_ObjId * self, PyObject * args,
             {
                 return 0;
             }
-            err << "cannot convert " << Field<string>::get(self->oid_, "className")
+            err << "cannot convert moose." << Field<string>::get(self->oid_, "className")
                 << " to " << mytypename
                 << "To get the existing object use `moose.element(obj)` instead.";
             PyErr_SetString(PyExc_TypeError, err.str().c_str());
@@ -250,7 +250,8 @@ int moose_ObjId_init_from_path(_ObjId * self, PyObject * args,
         if ( ii != get_moose_classes().end() )
         {
             basetype = ii->second;
-            basetype_str = string(basetype->tp_name).substr(6); // remove `moose.` prefix from type name
+            // remove `moose.` prefix from type name
+            basetype_str = string(basetype->tp_name).substr(6);
         }
         else
         {
@@ -258,7 +259,6 @@ int moose_ObjId_init_from_path(_ObjId * self, PyObject * args,
             basetype = getBaseClass((PyObject*)self);
         }
 
-#if 0
         // NOTE: Existing paths are handled in Shell::doCreate function.
         if ((basetype != NULL) && PyType_IsSubtype(mytype, basetype))
         {
@@ -267,14 +267,11 @@ int moose_ObjId_init_from_path(_ObjId * self, PyObject * args,
             moose::showWarn( warn.str( ) );
             return 0;
         }
-#endif
 
         // element exists at this path, but it does not inherit from any moose class.
         // throw an error
-        err << "cannot convert "
-            << className
-            << " to "
-            << mytypename
+        err << "cannot convert moose." << className
+            << " to " << mytypename
             << ". To get the existing object use `moose.element(obj)` instead.";
         PyErr_SetString(PyExc_TypeError, err.str().c_str());
         return -1;

--- a/pymoose/melement.cpp
+++ b/pymoose/melement.cpp
@@ -81,11 +81,16 @@ extern int PyType_IsSubtype(PyTypeObject *, PyTypeObject *);
 
 PyObject * get_ObjId_attr(_ObjId * oid, string attribute)
 {
-    if (attribute == "vec"){
+    if (attribute == "vec")
+    {
         return moose_ObjId_getId(oid);
-    } else if (attribute == "dindex"){
+    }
+    else if (attribute == "dindex")
+    {
         return moose_ObjId_getDataIndex(oid);
-    } else if (attribute == "findex"){
+    }
+    else if (attribute == "findex")
+    {
         return moose_ObjId_getFieldIndex(oid);
     }
     return NULL;
@@ -100,13 +105,16 @@ int moose_ObjId_init_from_id(_ObjId * self, PyObject * args, PyObject * kwargs)
     if (PyArg_ParseTupleAndKeywords(args, kwargs,
                                     "I|II:moose_ObjId_init_from_id",
                                     (char**)kwlist,
-                                    &id, &data, &field)){
+                                    &id, &data, &field))
+    {
         PyErr_Clear();
-        if (!Id::isValid(id)){
+        if (!Id::isValid(id))
+        {
             RAISE_INVALID_ID(-1, "moose_ObjId_init_from_id");
         }
         self->oid_ = ObjId(Id(id), data, field );
-        if (self->oid_.bad()){
+        if (self->oid_.bad())
+        {
             PyErr_SetString(PyExc_ValueError, "Invalid ObjId");
             return -1;
         }
@@ -116,25 +124,33 @@ int moose_ObjId_init_from_id(_ObjId * self, PyObject * args, PyObject * kwargs)
     if (PyArg_ParseTupleAndKeywords(args, kwargs,
                                     "O|II:moose_ObjId_init_from_id",
                                     (char**)kwlist,
-                                    &obj, &data, &field)){
+                                    &obj, &data, &field))
+    {
         PyErr_Clear();
         // If first argument is an Id object, construct an ObjId out of it
-        if (Id_Check(obj)){
-            if (!Id::isValid(((_Id*)obj)->id_)){
+        if (Id_Check(obj))
+        {
+            if (!Id::isValid(((_Id*)obj)->id_))
+            {
                 RAISE_INVALID_ID(-1, "moose_ObjId_init_from_id");
             }
             self->oid_ = ObjId(((_Id*)obj)->id_, data, field );
-            if (self->oid_.bad()){
+            if (self->oid_.bad())
+            {
                 PyErr_SetString(PyExc_ValueError, "Invalid dataIndex/fieldIndex.");
                 return -1;
             }
             return 0;
-        } else if (PyObject_IsInstance(obj, (PyObject*)&ObjIdType)){
-            if (!Id::isValid(((_ObjId*)obj)->oid_.id)){
+        }
+        else if (PyObject_IsInstance(obj, (PyObject*)&ObjIdType))
+        {
+            if (!Id::isValid(((_ObjId*)obj)->oid_.id))
+            {
                 RAISE_INVALID_ID(-1, "moose_ObjId_init_from_id");
             }
             self->oid_ = ((_ObjId*)obj)->oid_;
-            if (self->oid_.bad()){
+            if (self->oid_.bad())
+            {
                 PyErr_SetString(PyExc_ValueError, "Invalid ObjId");
                 return -1;
             }
@@ -162,42 +178,55 @@ int moose_ObjId_init_from_path(_ObjId * self, PyObject * args,
     if (PyArg_ParseTupleAndKeywords(args, kwargs,
                                     "s|IIs:moose_ObjId_init_from_path",
                                     (char**)kwlist,
-                                    &parsedPath, &numData, &isGlobal, &type)){
+                                    &parsedPath, &numData, &isGlobal, &type))
+    {
         parse_success = true;
     }
     // we need to clear the parse error so that the callee can try
     // other alternative: moose_ObjId_init_from_id
     PyErr_Clear();
-    if (!parse_success){
+    if (!parse_success)
+    {
         return -2;
     }
 
     string path(parsedPath);
+
     // Remove one or more instances of '/' by a single '/' e.g. //a -> /a,
     // /a//b -> /a/b etc.
     path = moose::fix(path);
 
-    ostringstream err;
+    ostringstream err, warn;
+
     // First see if there is an existing object with at path
     self->oid_ = ObjId(path);
     PyTypeObject* basetype = getBaseClass((PyObject*)self);
     string basetype_str;
-    if (type == NULL){
-        if (basetype == NULL){
-            PyErr_SetString(PyExc_TypeError, "Unknown class. Need a valid MOOSE class or subclass thereof.");
+    if (type == NULL)
+    {
+        if (basetype == NULL)
+        {
+            PyErr_SetString(PyExc_TypeError
+                            , "Unknown class. Need a valid MOOSE class or subclass thereof."
+                           );
             return -1;
         }
         basetype_str = string(basetype->tp_name).substr(6); // remove `moose.` prefix from type name
-    } else {
+    }
+    else
+    {
         basetype_str = string(type);
     }
 
 
     // If oid_ is bad, it can be either a nonexistent path or the root.
-    if (self->oid_.bad()){
+    if (self->oid_.bad())
+    {
         // is this the root element?
-        if ((path == "/") || (path == "/root")){
-            if ((basetype == NULL) || PyType_IsSubtype(mytype, basetype)){
+        if ((path == "/") || (path == "/root"))
+        {
+            if ((basetype == NULL) || PyType_IsSubtype(mytype, basetype))
+            {
                 return 0;
             }
             err << "cannot convert " << Field<string>::get(self->oid_, "className")
@@ -207,37 +236,54 @@ int moose_ObjId_init_from_path(_ObjId * self, PyObject * args,
             return -1;
         }
         // no - so we need to create a new element
-    } else { // this is a non-root existing element
+    }
+    else     // this is a non-root existing element
+    {
         // If the current class is a subclass of some predefined
         // moose class, do nothing.
         string className = self->oid_.element()->cinfo()->name();
         map <string, PyTypeObject * >::iterator ii =
-        	get_moose_classes().find( className );
+            get_moose_classes().find( className );
+
         PyTypeObject * basetype = 0;
-        if ( ii != get_moose_classes().end() ) {
-    	    basetype = ii->second;
+        if ( ii != get_moose_classes().end() )
+        {
+            basetype = ii->second;
             basetype_str = string(basetype->tp_name).substr(6); // remove `moose.` prefix from type name
-        } else {
+        }
+        else
+        {
             err << "Unknown class: " << className << endl;
             basetype = getBaseClass((PyObject*)self);
         }
-        if ((basetype != NULL) && PyType_IsSubtype(mytype, basetype)){
+
+#if 0
+        // NOTE: Existing paths are handled in Shell::doCreate function.
+        if ((basetype != NULL) && PyType_IsSubtype(mytype, basetype))
+        {
+            // Fine. This path already exits.
+            warn << "Path " << self->oid_.path( ) << "alread exists. Not creating nothing!" << endl;
             return 0;
         }
+#endif
+
         // element exists at this path, but it does not inherit from any moose class.
         // throw an error
         err << "cannot convert "
-			<< className
+            << className
             << " to "
             << mytypename
             << ". To get the existing object use `moose.element(obj)` instead.";
         PyErr_SetString(PyExc_TypeError, err.str().c_str());
         return -1;
     }
+
     // try to create new vec
     Id new_id = create_Id_from_path(path, numData, isGlobal, basetype_str);
+
     // vec failed. throw error
-    if (new_id == Id() && PyErr_Occurred()){
+    if (new_id == Id() && PyErr_Occurred())
+    {
         // Py_XDECREF(self);
         return -1;
     }
@@ -249,7 +295,8 @@ int moose_ObjId_init_from_path(_ObjId * self, PyObject * args,
 int moose_ObjId_init(_ObjId * self, PyObject * args,
                      PyObject * kwargs)
 {
-    if (self && !PyObject_IsInstance((PyObject*)self, (PyObject*)Py_TYPE((PyObject*)self))){
+    if (self && !PyObject_IsInstance((PyObject*)self, (PyObject*)Py_TYPE((PyObject*)self)))
+    {
         ostringstream error;
         error << "Expected an melement or subclass. Found "
               << Py_TYPE(self)->tp_name;
@@ -257,11 +304,13 @@ int moose_ObjId_init(_ObjId * self, PyObject * args,
         return -1;
     }
     int ret = moose_ObjId_init_from_path(self, args, kwargs);
-    if (ret >= -1){
+    if (ret >= -1)
+    {
         return ret;
     }
     // parsing arguments as (path, dims, classname) failed. See if it is existing Id or ObjId.
-    if (moose_ObjId_init_from_id(self, args, kwargs) == 0){
+    if (moose_ObjId_init_from_id(self, args, kwargs) == 0)
+    {
         return 0;
     }
     PyErr_SetString(PyExc_ValueError,
@@ -282,7 +331,8 @@ int moose_ObjId_init(_ObjId * self, PyObject * args,
 */
 long moose_ObjId_hash(_ObjId * self)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(-1, "moose_ObjId_hash");
     }
     long long id = (long long)(self->oid_.id.value());
@@ -291,16 +341,20 @@ long moose_ObjId_hash(_ObjId * self)
     /* attempt to make it with 32 bit system - assuming id will
      * have its value within least significant 16 bits and
      * dataIndex and fieldIndex will be limited to first 8 bits */
-    if (sizeof(size_t) == 8){
+    if (sizeof(size_t) == 8)
+    {
         return id << 48 | dataIndex << 16 | fieldIndex;
-    } else {
+    }
+    else
+    {
         return id << 16 | dataIndex << 8 | fieldIndex;
     }
 }
 
 PyObject * moose_ObjId_repr(_ObjId * self)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_repr");
     }
     ostringstream repr;
@@ -313,7 +367,8 @@ PyObject * moose_ObjId_repr(_ObjId * self)
 
 PyObject * moose_ObjId_str(_ObjId * self)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_str");
     }
     ostringstream repr;
@@ -337,7 +392,8 @@ PyDoc_STRVAR(moose_ObjId_getId_documentation,
              "\n");
 PyObject* moose_ObjId_getId(_ObjId * self)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_getId");
     }
     extern PyTypeObject IdType;
@@ -362,16 +418,19 @@ PyDoc_STRVAR(moose_ObjId_getFieldType_documentation,
 
 PyObject * moose_ObjId_getFieldType(_ObjId * self, PyObject * args)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_getFieldType");
     }
     char * fieldName = NULL;
-    if (!PyArg_ParseTuple(args, "s:moose_ObjId_getFieldType", &fieldName)){
+    if (!PyArg_ParseTuple(args, "s:moose_ObjId_getFieldType", &fieldName))
+    {
         return NULL;
     }
     string typeStr = getFieldType(Field<string>::get(self->oid_, "className"),
                                   string(fieldName));
-    if (typeStr.length() <= 0){
+    if (typeStr.length() <= 0)
+    {
         PyErr_SetString(PyExc_ValueError,
                         "Empty string for field type. "
                         "Field name may be incorrect.");
@@ -399,11 +458,13 @@ PyDoc_STRVAR(moose_ObjId_getField_documentation,
              "      >>> 0.0 \n");
 PyObject * moose_ObjId_getField(_ObjId * self, PyObject * args)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_getField");
     }
     PyObject * attr;
-    if (!PyArg_ParseTuple(args, "O:moose_ObjId_getField", &attr)){
+    if (!PyArg_ParseTuple(args, "O:moose_ObjId_getField", &attr))
+    {
         return NULL;
     }
     return moose_ObjId_getattro(self, attr);
@@ -422,43 +483,54 @@ PyObject * moose_ObjId_getField(_ObjId * self, PyObject * args)
 PyObject * moose_ObjId_getattro(_ObjId * self, PyObject * attr)
 {
     int new_attr = 0;
-    if (self->oid_.bad()){
+    if (self->oid_.bad())
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_getattro");
     }
     // extern PyTypeObject IdType;
     // extern PyTypeObject ObjIdType;
     const char * field;
     char ftype;
-    if (PyString_Check(attr)){
+    if (PyString_Check(attr))
+    {
         field = PyString_AsString(attr);
-    } else {
+    }
+    else
+    {
         return PyObject_GenericGetAttr((PyObject*)self, attr);
     }
     PyObject * _ret = get_ObjId_attr(self, field);
-    if (_ret != NULL){
+    if (_ret != NULL)
+    {
         return _ret;
     }
     string fieldName(field);
     string className = Field<string>::get(self->oid_, "className");
     vector<string> valueFinfos = getFieldNames(className, "valueFinfo");
     bool isValueField = false;
-    for (unsigned int ii = 0; ii < valueFinfos.size(); ++ii){
-        if (fieldName == valueFinfos[ii]){
+    for (unsigned int ii = 0; ii < valueFinfos.size(); ++ii)
+    {
+        if (fieldName == valueFinfos[ii])
+        {
             isValueField = true;
             break;
         }
     }
 
     string type = getFieldType(className, fieldName);
-    if (type.empty() || !isValueField ){
+    if (type.empty() || !isValueField )
+    {
         // Check if this field name is aliased and update fieldName and type if so.
         map<string, string>::const_iterator it = get_field_alias().find(fieldName);
-        if (it != get_field_alias().end()){
+        if (it != get_field_alias().end())
+        {
             fieldName = it->second;
             field = fieldName.c_str();
             isValueField = false;
-            for (unsigned int ii = 0; ii < valueFinfos.size(); ++ii){
-                if (fieldName == valueFinfos[ii]){
+            for (unsigned int ii = 0; ii < valueFinfos.size(); ++ii)
+            {
+                if (fieldName == valueFinfos[ii])
+                {
                     isValueField = true;
                     break;
                 }
@@ -470,186 +542,225 @@ PyObject * moose_ObjId_getattro(_ObjId * self, PyObject * attr)
             new_attr = 1;
         }
     }
-    if (type.empty() || !isValueField){
+    if (type.empty() || !isValueField)
+    {
         _ret = PyObject_GenericGetAttr((PyObject*)self, attr);
-        if (new_attr){
+        if (new_attr)
+        {
             Py_DECREF(attr);
         }
         return _ret;
     }
     ftype = shortType(type);
-    if (!ftype){
+    if (!ftype)
+    {
         _ret = PyObject_GenericGetAttr((PyObject*)self, attr);
-        if (new_attr){
+        if (new_attr)
+        {
             Py_DECREF(attr);
         }
         return _ret;
     }
     fieldName= string(field);
-    switch(ftype){
-        case 's': {
-            string _s = Field<string>::get(self->oid_, fieldName);
-            _ret = Py_BuildValue("s", _s.c_str());
-            break;
-        }
-        case 'd': {
-            double value = Field< double >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'i': {
-            int value = Field<int>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'I': {
-            unsigned int value = Field<unsigned int>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'l': {
-            long value = Field<long>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'L': {
-            long long value = Field<long long>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'k': {
-            unsigned long value = Field<unsigned long>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'K': {
-            unsigned long long value = Field<unsigned long long>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'f': {
-            float value = Field<float>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'x': {
-            Id value = Field<Id>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'y': {
-            ObjId value = Field<ObjId>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'z': {
-            PyErr_SetString(PyExc_NotImplementedError, "DataId handling not implemented yet.");
-            _ret = NULL;
-            break;
-        }
-        case 'D': {
-            vector< double > value = Field< vector < double > >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'X': { // vector<Id>
-            vector < Id > value = Field<vector <Id> >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'Y': { // vector<ObjId>
-            vector < ObjId > value = Field<vector <ObjId> >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'M': {
-            vector< long > value = Field< vector <long> >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'P': {
-            vector < unsigned long > value = Field< vector < unsigned long > >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'S': {
-            vector < string > value = Field<vector <string> >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'v': {
-            vector < int > value = Field<vector <int> >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'N': {
-            vector <unsigned int > value = Field< vector < unsigned int> >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'T': { // vector<vector < unsigned int >>
-            vector < vector < unsigned int > > value = Field<vector <vector < unsigned int > > >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'Q': { // vector< vector < int > >
-            vector <  vector < int >  > value = Field<vector < vector < int > > >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'R': { // vector< vector < double > >
-            vector <  vector < double >  > value = Field<vector < vector < double > > >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'F': {
-            vector <float> value = Field< vector < float > >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'c': {
-            char value = Field<char>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'h': {
-            short value = Field<short>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'H': {
-            unsigned short value = Field<unsigned short>::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'w': {
-            vector < short > value = Field<vector <short> >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
-        case 'C': {
-            vector < char > value = Field<vector <char> >::get(self->oid_, fieldName);
-            _ret = to_py(&value, ftype);
-            break;
-        }
+    switch(ftype)
+    {
+    case 's':
+    {
+        string _s = Field<string>::get(self->oid_, fieldName);
+        _ret = Py_BuildValue("s", _s.c_str());
+        break;
+    }
+    case 'd':
+    {
+        double value = Field< double >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'i':
+    {
+        int value = Field<int>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'I':
+    {
+        unsigned int value = Field<unsigned int>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'l':
+    {
+        long value = Field<long>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'L':
+    {
+        long long value = Field<long long>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'k':
+    {
+        unsigned long value = Field<unsigned long>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'K':
+    {
+        unsigned long long value = Field<unsigned long long>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'f':
+    {
+        float value = Field<float>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'x':
+    {
+        Id value = Field<Id>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'y':
+    {
+        ObjId value = Field<ObjId>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'z':
+    {
+        PyErr_SetString(PyExc_NotImplementedError, "DataId handling not implemented yet.");
+        _ret = NULL;
+        break;
+    }
+    case 'D':
+    {
+        vector< double > value = Field< vector < double > >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'X':   // vector<Id>
+    {
+        vector < Id > value = Field<vector <Id> >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'Y':   // vector<ObjId>
+    {
+        vector < ObjId > value = Field<vector <ObjId> >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'M':
+    {
+        vector< long > value = Field< vector <long> >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'P':
+    {
+        vector < unsigned long > value = Field< vector < unsigned long > >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'S':
+    {
+        vector < string > value = Field<vector <string> >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'v':
+    {
+        vector < int > value = Field<vector <int> >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'N':
+    {
+        vector <unsigned int > value = Field< vector < unsigned int> >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'T':   // vector<vector < unsigned int >>
+    {
+        vector < vector < unsigned int > > value = Field<vector <vector < unsigned int > > >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'Q':   // vector< vector < int > >
+    {
+        vector <  vector < int >  > value = Field<vector < vector < int > > >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'R':   // vector< vector < double > >
+    {
+        vector <  vector < double >  > value = Field<vector < vector < double > > >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'F':
+    {
+        vector <float> value = Field< vector < float > >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'c':
+    {
+        char value = Field<char>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'h':
+    {
+        short value = Field<short>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'H':
+    {
+        unsigned short value = Field<unsigned short>::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'w':
+    {
+        vector < short > value = Field<vector <short> >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
+    case 'C':
+    {
+        vector < char > value = Field<vector <char> >::get(self->oid_, fieldName);
+        _ret = to_py(&value, ftype);
+        break;
+    }
 
-        case 'b': {
-            bool value = Field<bool>::get(self->oid_, fieldName);
-            if (value){
-                _ret = Py_True;
-                Py_INCREF(Py_True);
-            } else {
-                _ret = Py_False;
-                Py_INCREF(Py_False);
-            }
-            break;
+    case 'b':
+    {
+        bool value = Field<bool>::get(self->oid_, fieldName);
+        if (value)
+        {
+            _ret = Py_True;
+            Py_INCREF(Py_True);
         }
+        else
+        {
+            _ret = Py_False;
+            Py_INCREF(Py_False);
+        }
+        break;
+    }
 
-        default:
-            _ret = PyObject_GenericGetAttr((PyObject*)self, attr);
+    default:
+        _ret = PyObject_GenericGetAttr((PyObject*)self, attr);
 
     }
-    if (new_attr){
+    if (new_attr)
+    {
         Py_DECREF(attr);
     }
     return _ret;
@@ -680,10 +791,12 @@ PyObject * moose_ObjId_setField(_ObjId * self, PyObject * args)
 {
     PyObject * field;
     PyObject * value;
-    if (!PyArg_ParseTuple(args, "OO:moose_ObjId_setField", &field, &value)){
+    if (!PyArg_ParseTuple(args, "OO:moose_ObjId_setField", &field, &value))
+    {
         return NULL;
     }
-    if (moose_ObjId_setattro(self, field, value) == -1){
+    if (moose_ObjId_setattro(self, field, value) == -1)
+    {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -694,25 +807,31 @@ PyObject * moose_ObjId_setField(_ObjId * self, PyObject * args)
 */
 int  moose_ObjId_setattro(_ObjId * self, PyObject * attr, PyObject * value)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(-1, "moose_ObjId_setattro");
     }
     const char * field;
-    if (PyString_Check(attr)){
+    if (PyString_Check(attr))
+    {
         field = PyString_AsString(attr);
-    } else {
+    }
+    else
+    {
         PyErr_SetString(PyExc_TypeError, "Attribute name must be a string");
         return -1;
     }
     string fieldtype = getFieldType(Field<string>::get(self->oid_, "className"), string(field));
-    if (fieldtype.length() == 0){
+    if (fieldtype.length() == 0)
+    {
         // If it is instance of a MOOSE built-in class then throw
         // error (to avoid silently creating new attributes due to
         // typos). Otherwise, it must have been subclassed in
         // Python. Then we allow normal Pythonic behaviour and
         // consider such mistakes user's responsibility.
         string className = ((PyTypeObject*)PyObject_Type((PyObject*)self))->tp_name;
-        if (get_moose_classes().find(className) == get_moose_classes().end()){
+        if (get_moose_classes().find(className) == get_moose_classes().end())
+        {
             return PyObject_GenericSetAttr((PyObject*)self, PyString_FromString(field), value);
         }
         ostringstream msg;
@@ -722,282 +841,364 @@ int  moose_ObjId_setattro(_ObjId * self, PyObject * attr, PyObject * value)
     }
     char ftype = shortType(fieldtype);
     int ret = 0;
-    switch(ftype){
-        case 'd': {
-            double _value = PyFloat_AsDouble(value);
-            ret = Field<double>::set(self->oid_, string(field), _value);
-            break;
+    switch(ftype)
+    {
+    case 'd':
+    {
+        double _value = PyFloat_AsDouble(value);
+        ret = Field<double>::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'l':
+    {
+        long _value = PyInt_AsLong(value);
+        if ((_value != -1) || (!PyErr_Occurred()))
+        {
+            ret = Field<long>::set(self->oid_, string(field), _value);
         }
-        case 'l': {
-            long _value = PyInt_AsLong(value);
-            if ((_value != -1) || (!PyErr_Occurred())){
-                ret = Field<long>::set(self->oid_, string(field), _value);
-            }
-            break;
+        break;
+    }
+    case 'I':
+    {
+        unsigned long _value = PyInt_AsUnsignedLongMask(value);
+        ret = Field<unsigned int>::set(self->oid_, string(field), (unsigned int)_value);
+        break;
+    }
+    case 'k':
+    {
+        unsigned long _value = PyInt_AsUnsignedLongMask(value);
+        ret = Field<unsigned long>::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'f':
+    {
+        float _value = PyFloat_AsDouble(value);
+        ret = Field<float>::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 's':
+    {
+        char * _value = PyString_AsString(value);
+        if (_value)
+        {
+            ret = Field<string>::set(self->oid_, string(field), string(_value));
         }
-        case 'I': {
-            unsigned long _value = PyInt_AsUnsignedLongMask(value);
-            ret = Field<unsigned int>::set(self->oid_, string(field), (unsigned int)_value);
-            break;
+        break;
+    }
+    case 'x':  // Id
+    {
+        if (value)
+        {
+            ret = Field<Id>::set(self->oid_, string(field), ((_Id*)value)->id_);
         }
-        case 'k': {
-            unsigned long _value = PyInt_AsUnsignedLongMask(value);
-            ret = Field<unsigned long>::set(self->oid_, string(field), _value);
-            break;
-        }
-        case 'f': {
-            float _value = PyFloat_AsDouble(value);
-            ret = Field<float>::set(self->oid_, string(field), _value);
-            break;
-        }
-        case 's': {
-            char * _value = PyString_AsString(value);
-            if (_value){
-                ret = Field<string>::set(self->oid_, string(field), string(_value));
-            }
-            break;
-        }
-        case 'x': {// Id
-            if (value){
-                ret = Field<Id>::set(self->oid_, string(field), ((_Id*)value)->id_);
-            } else {
-                PyErr_SetString(PyExc_ValueError, "Null pointer passed as vec Id value.");
-                return -1;
-            }
-            break;
-        }
-        case 'y': {// ObjId
-            if (value){
-                ret = Field<ObjId>::set(self->oid_, string(field), ((_ObjId*)value)->oid_);
-            } else {
-                PyErr_SetString(PyExc_ValueError, "Null pointer passed as vec Id value.");
-                return -1;
-            }
-            break;
-        }
-        case 'D': {//SET_VECFIELD(double, d)
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError, "For setting vector<double> field, specified value must be a sequence." );
-            } else {
-                Py_ssize_t length = PySequence_Length(value);
-                vector<double> _value;
-                for ( int ii = 0; ii < length; ++ii){
-                    PyObject * vo = PySequence_GetItem(value, ii);
-                    double v = PyFloat_AsDouble(vo);
-                    Py_XDECREF(vo);
-                    _value.push_back(v);
-                }
-                ret = Field< vector < double > >::set(self->oid_, string(field), _value);
-            }
-            break;
-        }
-        case 'b': {
-            bool _value = (Py_True == value) || (PyInt_AsLong(value) != 0);
-            ret = Field<bool>::set(self->oid_, string(field), _value);
-            break;
-        }
-        case 'c': {
-            char * _value = PyString_AsString(value);
-            if (_value && _value[0]){
-                ret = Field<char>::set(self->oid_, string(field), _value[0]);
-            }
-            break;
-        }
-        case 'i': {
-            int _value = PyInt_AsLong(value);
-            if ((_value != -1) || (!PyErr_Occurred())){
-                ret = Field<int>::set(self->oid_, string(field), _value);
-            }
-            break;
-        }
-        case 'h':{
-            short _value = (short)PyInt_AsLong(value);
-            if ((_value != -1) || (!PyErr_Occurred())){
-                ret = Field<short>::set(self->oid_, string(field), _value);
-            }
-            break;
-        }
-        case 'z': {// DataId
-            PyErr_SetString(PyExc_NotImplementedError, "DataId handling not implemented yet.");
+        else
+        {
+            PyErr_SetString(PyExc_ValueError, "Null pointer passed as vec Id value.");
             return -1;
         }
-        case 'v': {
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError, "For setting vector<int> field, specified value must be a sequence." );
-            }
+        break;
+    }
+    case 'y':  // ObjId
+    {
+        if (value)
+        {
+            ret = Field<ObjId>::set(self->oid_, string(field), ((_ObjId*)value)->oid_);
+        }
+        else
+        {
+            PyErr_SetString(PyExc_ValueError, "Null pointer passed as vec Id value.");
+            return -1;
+        }
+        break;
+    }
+    case 'D':  //SET_VECFIELD(double, d)
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError, "For setting vector<double> field, specified value must be a sequence." );
+        }
+        else
+        {
             Py_ssize_t length = PySequence_Length(value);
-            vector<int> _value;
-            for ( int ii = 0; ii < length; ++ii){
+            vector<double> _value;
+            for ( int ii = 0; ii < length; ++ii)
+            {
                 PyObject * vo = PySequence_GetItem(value, ii);
-                int v = PyInt_AsLong(vo);
+                double v = PyFloat_AsDouble(vo);
                 Py_XDECREF(vo);
                 _value.push_back(v);
             }
-            ret = Field< vector < int > >::set(self->oid_, string(field), _value);
-            break;
+            ret = Field< vector < double > >::set(self->oid_, string(field), _value);
         }
-        case 'w': {
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError, "For setting vector<short> field, specified value must be a sequence." );
-            } else {
-                Py_ssize_t length = PySequence_Length(value);
-                vector<short> _value;
-                for ( int ii = 0; ii < length; ++ii){
-                    PyObject * vo = PySequence_GetItem(value, ii);
-                    short v = PyInt_AsLong(vo);
-                    Py_XDECREF(vo);
-                    _value.push_back(v);
-                }
-                ret = Field< vector < short > >::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'b':
+    {
+        bool _value = (Py_True == value) || (PyInt_AsLong(value) != 0);
+        ret = Field<bool>::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'c':
+    {
+        char * _value = PyString_AsString(value);
+        if (_value && _value[0])
+        {
+            ret = Field<char>::set(self->oid_, string(field), _value[0]);
+        }
+        break;
+    }
+    case 'i':
+    {
+        int _value = PyInt_AsLong(value);
+        if ((_value != -1) || (!PyErr_Occurred()))
+        {
+            ret = Field<int>::set(self->oid_, string(field), _value);
+        }
+        break;
+    }
+    case 'h':
+    {
+        short _value = (short)PyInt_AsLong(value);
+        if ((_value != -1) || (!PyErr_Occurred()))
+        {
+            ret = Field<short>::set(self->oid_, string(field), _value);
+        }
+        break;
+    }
+    case 'z':  // DataId
+    {
+        PyErr_SetString(PyExc_NotImplementedError, "DataId handling not implemented yet.");
+        return -1;
+    }
+    case 'v':
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError, "For setting vector<int> field, specified value must be a sequence." );
+        }
+        Py_ssize_t length = PySequence_Length(value);
+        vector<int> _value;
+        for ( int ii = 0; ii < length; ++ii)
+        {
+            PyObject * vo = PySequence_GetItem(value, ii);
+            int v = PyInt_AsLong(vo);
+            Py_XDECREF(vo);
+            _value.push_back(v);
+        }
+        ret = Field< vector < int > >::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'w':
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError, "For setting vector<short> field, specified value must be a sequence." );
+        }
+        else
+        {
+            Py_ssize_t length = PySequence_Length(value);
+            vector<short> _value;
+            for ( int ii = 0; ii < length; ++ii)
+            {
+                PyObject * vo = PySequence_GetItem(value, ii);
+                short v = PyInt_AsLong(vo);
+                Py_XDECREF(vo);
+                _value.push_back(v);
             }
-            break;
+            ret = Field< vector < short > >::set(self->oid_, string(field), _value);
         }
-        case 'L': {//SET_VECFIELD(long, l)
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError,
-                                "For setting vector<long> field, specified value must be a sequence." );
-            } else {
-                Py_ssize_t length = PySequence_Length(value);
-                vector<long> _value;
-                for ( int ii = 0; ii < length; ++ii){
-                    PyObject * vo = PySequence_GetItem(value, ii);
-                    long v = PyInt_AsLong(vo);
-                    Py_XDECREF(vo);
-                    _value.push_back(v);
-                }
-                ret = Field< vector < long > >::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'L':  //SET_VECFIELD(long, l)
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError,
+                            "For setting vector<long> field, specified value must be a sequence." );
+        }
+        else
+        {
+            Py_ssize_t length = PySequence_Length(value);
+            vector<long> _value;
+            for ( int ii = 0; ii < length; ++ii)
+            {
+                PyObject * vo = PySequence_GetItem(value, ii);
+                long v = PyInt_AsLong(vo);
+                Py_XDECREF(vo);
+                _value.push_back(v);
             }
-            break;
+            ret = Field< vector < long > >::set(self->oid_, string(field), _value);
         }
-        case 'N': {//SET_VECFIELD(unsigned int, I)
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError, "For setting vector<unsigned int> field, specified value must be a sequence." );
-            } else {
-                Py_ssize_t length = PySequence_Length(value);
-                vector<unsigned int> _value;
-                for ( int ii = 0; ii < length; ++ii){
-                    PyObject * vo = PySequence_GetItem(value, ii);
-                    unsigned int v = PyInt_AsUnsignedLongMask(vo);
-                    Py_XDECREF(vo);
-                    _value.push_back(v);
-                }
-                ret = Field< vector < unsigned int > >::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'N':  //SET_VECFIELD(unsigned int, I)
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError, "For setting vector<unsigned int> field, specified value must be a sequence." );
+        }
+        else
+        {
+            Py_ssize_t length = PySequence_Length(value);
+            vector<unsigned int> _value;
+            for ( int ii = 0; ii < length; ++ii)
+            {
+                PyObject * vo = PySequence_GetItem(value, ii);
+                unsigned int v = PyInt_AsUnsignedLongMask(vo);
+                Py_XDECREF(vo);
+                _value.push_back(v);
             }
-            break;
+            ret = Field< vector < unsigned int > >::set(self->oid_, string(field), _value);
         }
-        case 'K': {//SET_VECFIELD(unsigned long, k)
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError, "For setting vector<unsigned long> field, specified value must be a sequence." );
-            } else {
-                Py_ssize_t length = PySequence_Length(value);
-                vector<unsigned long> _value;
-                for ( int ii = 0; ii < length; ++ii){
-                    PyObject * vo = PySequence_GetItem(value, ii);
-                    unsigned long v = PyInt_AsUnsignedLongMask(vo);
-                    Py_XDECREF(vo);
-                    _value.push_back(v);
-                }
-                ret = Field< vector < unsigned long > >::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'K':  //SET_VECFIELD(unsigned long, k)
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError, "For setting vector<unsigned long> field, specified value must be a sequence." );
+        }
+        else
+        {
+            Py_ssize_t length = PySequence_Length(value);
+            vector<unsigned long> _value;
+            for ( int ii = 0; ii < length; ++ii)
+            {
+                PyObject * vo = PySequence_GetItem(value, ii);
+                unsigned long v = PyInt_AsUnsignedLongMask(vo);
+                Py_XDECREF(vo);
+                _value.push_back(v);
             }
-            break;
+            ret = Field< vector < unsigned long > >::set(self->oid_, string(field), _value);
         }
-        case 'F': {//SET_VECFIELD(float, f)
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError, "For setting vector<float> field, specified value must be a sequence." );
-            } else {
-                Py_ssize_t length = PySequence_Length(value);
-                vector<float> _value;
-                for ( int ii = 0; ii < length; ++ii){
-                    PyObject * vo = PySequence_GetItem(value, ii);
-                    float v = PyFloat_AsDouble(vo);
-                    Py_XDECREF(vo);
-                    _value.push_back(v);
-                }
-                ret = Field< vector < float > >::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'F':  //SET_VECFIELD(float, f)
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError, "For setting vector<float> field, specified value must be a sequence." );
+        }
+        else
+        {
+            Py_ssize_t length = PySequence_Length(value);
+            vector<float> _value;
+            for ( int ii = 0; ii < length; ++ii)
+            {
+                PyObject * vo = PySequence_GetItem(value, ii);
+                float v = PyFloat_AsDouble(vo);
+                Py_XDECREF(vo);
+                _value.push_back(v);
             }
-            break;
+            ret = Field< vector < float > >::set(self->oid_, string(field), _value);
         }
-        case 'S': {
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError, "For setting vector<string> field, specified value must be a sequence." );
-            } else {
-                Py_ssize_t length = PySequence_Length(value);
-                vector<string> _value;
-                for ( int ii = 0; ii < length; ++ii){
-                    PyObject * vo = PySequence_GetItem(value, ii);
-                    char * v = PyString_AsString(vo);
-                    Py_XDECREF(vo);
-                    _value.push_back(string(v));
-                }
-                ret = Field< vector < string > >::set(self->oid_, string(field), _value);
+        break;
+    }
+    case 'S':
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError, "For setting vector<string> field, specified value must be a sequence." );
+        }
+        else
+        {
+            Py_ssize_t length = PySequence_Length(value);
+            vector<string> _value;
+            for ( int ii = 0; ii < length; ++ii)
+            {
+                PyObject * vo = PySequence_GetItem(value, ii);
+                char * v = PyString_AsString(vo);
+                Py_XDECREF(vo);
+                _value.push_back(string(v));
             }
-            break;
+            ret = Field< vector < string > >::set(self->oid_, string(field), _value);
         }
-        case 'T': {// vector< vector<unsigned int> >
-            vector < vector <unsigned> > * _value = (vector < vector <unsigned> > *)to_cpp(value, ftype);
-            if (!PyErr_Occurred()){
-                ret = Field < vector < vector <unsigned> > >::set(self->oid_, string(field), *_value);
+        break;
+    }
+    case 'T':  // vector< vector<unsigned int> >
+    {
+        vector < vector <unsigned> > * _value = (vector < vector <unsigned> > *)to_cpp(value, ftype);
+        if (!PyErr_Occurred())
+        {
+            ret = Field < vector < vector <unsigned> > >::set(self->oid_, string(field), *_value);
+        }
+        delete _value;
+        break;
+    }
+    case 'Q':  // vector< vector<int> >
+    {
+        vector < vector <int> > * _value = (vector < vector <int> > *)to_cpp(value, ftype);
+        if (!PyErr_Occurred())
+        {
+            ret = Field < vector < vector <int> > >::set(self->oid_, string(field), *_value);
+        }
+        delete _value;
+        break;
+    }
+    case 'R':  // vector< vector<double> >
+    {
+        vector < vector <double> > * _value = (vector < vector <double> > *)to_cpp(value, ftype);
+        if (!PyErr_Occurred())
+        {
+            ret = Field < vector < vector <double> > >::set(self->oid_, string(field), *_value);
+        }
+        delete _value;
+        break;
+    }
+    case 'X':  //SET_VECFIELD(Id, f)
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError, "For setting vector<Id> field, specified value must be a sequence." );
+        }
+        else
+        {
+            Py_ssize_t length = PySequence_Length(value);
+            vector<Id> _value;
+            for ( int ii = 0; ii < length; ++ii)
+            {
+                PyObject * vo = PySequence_GetItem(value, ii);
+                Id v = ((_Id*)vo)->id_;
+                Py_XDECREF(vo);
+                _value.push_back(v);
             }
-            delete _value;
-            break;
+            ret = Field< vector < Id > >::set(self->oid_, string(field), _value);
         }
-        case 'Q': {// vector< vector<int> >
-            vector < vector <int> > * _value = (vector < vector <int> > *)to_cpp(value, ftype);
-            if (!PyErr_Occurred()){
-                ret = Field < vector < vector <int> > >::set(self->oid_, string(field), *_value);
+        break;
+    }
+    case 'Y':  //SET_VECFIELD(ObjId, f)
+    {
+        if (!PySequence_Check(value))
+        {
+            PyErr_SetString(PyExc_TypeError, "For setting vector<ObjId> field, specified value must be a sequence." );
+        }
+        else
+        {
+            Py_ssize_t length = PySequence_Length(value);
+            vector<ObjId> _value;
+            for ( int ii = 0; ii < length; ++ii)
+            {
+                PyObject * vo = PySequence_GetItem(value, ii);
+                ObjId v = ((_ObjId*)vo)->oid_;
+                Py_XDECREF(vo);
+                _value.push_back(v);
             }
-            delete _value;
-            break;
+            ret = Field< vector < ObjId > >::set(self->oid_, string(field), _value);
         }
-        case 'R': {// vector< vector<double> >
-            vector < vector <double> > * _value = (vector < vector <double> > *)to_cpp(value, ftype);
-            if (!PyErr_Occurred()){
-                ret = Field < vector < vector <double> > >::set(self->oid_, string(field), *_value);
-            }
-            delete _value;
-            break;
-        }
-        case 'X': {//SET_VECFIELD(Id, f)
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError, "For setting vector<Id> field, specified value must be a sequence." );
-            } else {
-                Py_ssize_t length = PySequence_Length(value);
-                vector<Id> _value;
-                for ( int ii = 0; ii < length; ++ii){
-                    PyObject * vo = PySequence_GetItem(value, ii);
-                    Id v = ((_Id*)vo)->id_;
-                    Py_XDECREF(vo);
-                    _value.push_back(v);
-                }
-                ret = Field< vector < Id > >::set(self->oid_, string(field), _value);
-            }
-            break;
-        }
-        case 'Y': {//SET_VECFIELD(ObjId, f)
-            if (!PySequence_Check(value)){
-                PyErr_SetString(PyExc_TypeError, "For setting vector<ObjId> field, specified value must be a sequence." );
-            } else {
-                Py_ssize_t length = PySequence_Length(value);
-                vector<ObjId> _value;
-                for ( int ii = 0; ii < length; ++ii){
-                    PyObject * vo = PySequence_GetItem(value, ii);
-                    ObjId v = ((_ObjId*)vo)->oid_;
-                    Py_XDECREF(vo);
-                    _value.push_back(v);
-                }
-                ret = Field< vector < ObjId > >::set(self->oid_, string(field), _value);
-            }
-            break;
-        }
-        default:
-            break;
+        break;
+    }
+    default:
+        break;
     }
     // MOOSE Field::set returns 1 for success 0 for
     // failure. Python treats return value 0 from stters as
     // success, anything else failure.
-    if (ret){
+    if (ret)
+    {
         return 0;
-    } else {
+    }
+    else
+    {
         ostringstream msg;
         msg <<  "Failed to set field '"  << field << "'";
         PyErr_SetString(PyExc_AttributeError,msg.str().c_str());
@@ -1007,10 +1208,12 @@ int  moose_ObjId_setattro(_ObjId * self, PyObject * attr, PyObject * value)
 
 PyObject * moose_ObjId_getItem(_ObjId * self, Py_ssize_t index)
 {
-    if (index < 0){
+    if (index < 0)
+    {
         index += moose_ObjId_getLength(self);
     }
-    if ((index < 0) || (index >= moose_ObjId_getLength(self))){
+    if ((index < 0) || (index >= moose_ObjId_getLength(self)))
+    {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds.");
         return NULL;
     }
@@ -1036,13 +1239,16 @@ PyObject * moose_ObjId_getItem(_ObjId * self, Py_ssize_t index)
 PyObject * moose_ObjId_getSlice(_ObjId * self, Py_ssize_t start, Py_ssize_t end)
 {
     Py_ssize_t len = moose_ObjId_getLength(self);
-    while (start < 0){
+    while (start < 0)
+    {
         start += len;
     }
-    while (end < 0){
+    while (end < 0)
+    {
         end += len;
     }
-    if (start > end){
+    if (start > end)
+    {
         // PyErr_SetString(PyExc_IndexError, "Start index must be less than end.");
         // python itself returns empty tuple - follow that
         return PyTuple_New(0);
@@ -1050,10 +1256,12 @@ PyObject * moose_ObjId_getSlice(_ObjId * self, Py_ssize_t start, Py_ssize_t end)
     PyObject * ret = PyTuple_New((Py_ssize_t)(end - start));
 
     // Py_XINCREF(ret);
-    for ( int ii = start; ii < end; ++ii){
+    for ( int ii = start; ii < end; ++ii)
+    {
         _ObjId * value = PyObject_New(_ObjId, &ObjIdType);
         value->oid_ = ObjId(self->oid_.id, self->oid_.dataIndex, ii);
-        if (PyTuple_SetItem(ret, (Py_ssize_t)(ii-start), (PyObject*)value)){ // danger - must we DECREF all prior values?
+        if (PyTuple_SetItem(ret, (Py_ssize_t)(ii-start), (PyObject*)value))  // danger - must we DECREF all prior values?
+        {
             Py_XDECREF(ret);
             // Py_XDECREF(value);
             PyErr_SetString(PyExc_RuntimeError, "Failed to assign tuple entry.");
@@ -1067,11 +1275,13 @@ PyObject * moose_ObjId_getSlice(_ObjId * self, Py_ssize_t start, Py_ssize_t end)
 Py_ssize_t moose_ObjId_getLength(_ObjId * self)
 {
     Element * el = self->oid_.element();
-    if (!el->hasFields()){
+    if (!el->hasFields())
+    {
         return 0;
     }
     FieldElement * fe = reinterpret_cast< FieldElement* >(el);
-    if (fe == NULL){
+    if (fe == NULL)
+    {
         return 0;
     }
     return (Py_ssize_t)(fe->numData());
@@ -1084,13 +1294,15 @@ Py_ssize_t moose_ObjId_getLength(_ObjId * self)
 PyObject * getLookupField(ObjId target, char * fieldName, PyObject * key)
 {
     vector<string> type_vec;
-    if (parseFinfoType(Field<string>::get(target, "className"), "lookupFinfo", string(fieldName), type_vec) < 0){
+    if (parseFinfoType(Field<string>::get(target, "className"), "lookupFinfo", string(fieldName), type_vec) < 0)
+    {
         ostringstream error;
         error << "Cannot handle key type for LookupField `" << Field<string>::get(target, "className") << "." << fieldName << "`.";
         PyErr_SetString(PyExc_TypeError, error.str().c_str());
         return NULL;
     }
-    if (type_vec.size() != 2){
+    if (type_vec.size() != 2)
+    {
         ostringstream error;
         error << "LookupField type signature should be <keytype>, <valuetype>. But for `"
               << Field<string>::get(target, "className") << "." << fieldName << "` got " << type_vec.size() << " components." ;
@@ -1100,111 +1312,137 @@ PyObject * getLookupField(ObjId target, char * fieldName, PyObject * key)
     PyObject * ret = NULL;
     char key_type_code = shortType(type_vec[0]);
     char value_type_code = shortType(type_vec[1]);
-    switch(key_type_code){
-        case 'b': {
-            ret = lookup_value <bool> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'c': {
-            ret = lookup_value <char> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'h': {
-            ret = lookup_value <short> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'H': {
-            ret = lookup_value <unsigned short> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'i': {
-            ret = lookup_value <int> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'I': {
-            ret = lookup_value <unsigned int> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'l': {
-            ret = lookup_value <long> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'k': {
-            ret = lookup_value <unsigned long> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'L': {
-            ret = lookup_value <long long> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'K': {
-            ret = lookup_value <unsigned long long> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'd': {
-            ret = lookup_value <double> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'f': {
-            ret = lookup_value <float> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 's': {
-            ret = lookup_value <string> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'x': {
-            ret = lookup_value <Id> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'y': {
-            ret = lookup_value <ObjId> (target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'D': {
-            ret = lookup_value < vector <double> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'S': {
-            ret = lookup_value < vector <string> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'X': {
-            ret = lookup_value < vector <Id> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'Y': {
-            ret = lookup_value < vector <ObjId> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'v': {
-            ret = lookup_value < vector <int> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'N': {
-            ret = lookup_value < vector <unsigned int> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'P': {
-            ret = lookup_value < vector <unsigned long> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'F': {
-            ret = lookup_value < vector <float> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'w': {
-            ret = lookup_value < vector <short> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        case 'C': {
-            ret = lookup_value < vector <char> >(target, string(fieldName), value_type_code, key_type_code, key);
-            break;
-        }
-        default:
-            ostringstream error;
-            error << "Unhandled key type `" << type_vec[0] << "` for " << Field<string>::get(target, "className") << "." << fieldName;
-            PyErr_SetString(PyExc_TypeError, error.str().c_str());
+    switch(key_type_code)
+    {
+    case 'b':
+    {
+        ret = lookup_value <bool> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'c':
+    {
+        ret = lookup_value <char> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'h':
+    {
+        ret = lookup_value <short> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'H':
+    {
+        ret = lookup_value <unsigned short> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'i':
+    {
+        ret = lookup_value <int> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'I':
+    {
+        ret = lookup_value <unsigned int> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'l':
+    {
+        ret = lookup_value <long> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'k':
+    {
+        ret = lookup_value <unsigned long> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'L':
+    {
+        ret = lookup_value <long long> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'K':
+    {
+        ret = lookup_value <unsigned long long> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'd':
+    {
+        ret = lookup_value <double> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'f':
+    {
+        ret = lookup_value <float> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 's':
+    {
+        ret = lookup_value <string> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'x':
+    {
+        ret = lookup_value <Id> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'y':
+    {
+        ret = lookup_value <ObjId> (target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'D':
+    {
+        ret = lookup_value < vector <double> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'S':
+    {
+        ret = lookup_value < vector <string> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'X':
+    {
+        ret = lookup_value < vector <Id> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'Y':
+    {
+        ret = lookup_value < vector <ObjId> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'v':
+    {
+        ret = lookup_value < vector <int> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'N':
+    {
+        ret = lookup_value < vector <unsigned int> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'P':
+    {
+        ret = lookup_value < vector <unsigned long> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'F':
+    {
+        ret = lookup_value < vector <float> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'w':
+    {
+        ret = lookup_value < vector <short> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    case 'C':
+    {
+        ret = lookup_value < vector <char> >(target, string(fieldName), value_type_code, key_type_code, key);
+        break;
+    }
+    default:
+        ostringstream error;
+        error << "Unhandled key type `" << type_vec[0] << "` for " << Field<string>::get(target, "className") << "." << fieldName;
+        PyErr_SetString(PyExc_TypeError, error.str().c_str());
     }
     return ret;
 }
@@ -1225,12 +1463,14 @@ PyDoc_STRVAR(moose_ObjId_getLookupField_documentation,
 
 PyObject * moose_ObjId_getLookupField(_ObjId * self, PyObject * args)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_getLookupField");
     }
     char * fieldName = NULL;
     PyObject * key = NULL;
-    if (!PyArg_ParseTuple(args, "sO:moose_ObjId_getLookupField", &fieldName,  &key)){
+    if (!PyArg_ParseTuple(args, "sO:moose_ObjId_getLookupField", &fieldName,  &key))
+    {
         return NULL;
     }
     return getLookupField(self->oid_, fieldName, key);
@@ -1239,13 +1479,15 @@ PyObject * moose_ObjId_getLookupField(_ObjId * self, PyObject * args)
 int setLookupField(ObjId target, char * fieldName, PyObject * key, PyObject * value)
 {
     vector<string> type_vec;
-    if (parseFinfoType(Field<string>::get(target, "className"), "lookupFinfo", string(fieldName), type_vec) < 0){
+    if (parseFinfoType(Field<string>::get(target, "className"), "lookupFinfo", string(fieldName), type_vec) < 0)
+    {
         ostringstream error;
         error << "Cannot handle key type for LookupField `" << Field<string>::get(target, "className") << "." << fieldName << "`.";
         PyErr_SetString(PyExc_TypeError, error.str().c_str());
         return -1;
     }
-    if (type_vec.size() != 2){
+    if (type_vec.size() != 2)
+    {
         ostringstream error;
         error << "LookupField type signature should be <keytype>, <valuetype>. But for `"
               << Field<string>::get(target, "className") << "." << fieldName << "` got " << type_vec.size() << " components." ;
@@ -1255,71 +1497,87 @@ int setLookupField(ObjId target, char * fieldName, PyObject * key, PyObject * va
     char key_type_code = shortType(type_vec[0]);
     char value_type_code = shortType(type_vec[1]);
     int ret = -1;
-    switch(key_type_code){
-        case 'I': {
-            ret = set_lookup_value <unsigned int> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'k': {
-            ret = set_lookup_value <unsigned long> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 's': {
-            ret = set_lookup_value <string> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'i': {
-            ret = set_lookup_value <int> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'l': {
-            ret = set_lookup_value <long> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'L': {
-            ret = set_lookup_value <long long> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'K': {
-            ret = set_lookup_value <unsigned long long> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'b': {
-            ret = set_lookup_value <bool> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'c': {
-            ret = set_lookup_value <char> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'h': {
-            ret = set_lookup_value <short> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'H': {
-            ret = set_lookup_value <unsigned short> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'd': {
-            ret = set_lookup_value <double> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'f': {
-            ret = set_lookup_value <float> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'x': {
-            ret = set_lookup_value <Id> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        case 'y': {
-            ret = set_lookup_value <ObjId> (target, string(fieldName), value_type_code, key_type_code, key, value);
-            break;
-        }
-        default:
-            ostringstream error;
-            error << "setLookupField: invalid key type " << type_vec[0];
-            PyErr_SetString(PyExc_TypeError, error.str().c_str());
+    switch(key_type_code)
+    {
+    case 'I':
+    {
+        ret = set_lookup_value <unsigned int> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'k':
+    {
+        ret = set_lookup_value <unsigned long> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 's':
+    {
+        ret = set_lookup_value <string> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'i':
+    {
+        ret = set_lookup_value <int> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'l':
+    {
+        ret = set_lookup_value <long> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'L':
+    {
+        ret = set_lookup_value <long long> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'K':
+    {
+        ret = set_lookup_value <unsigned long long> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'b':
+    {
+        ret = set_lookup_value <bool> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'c':
+    {
+        ret = set_lookup_value <char> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'h':
+    {
+        ret = set_lookup_value <short> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'H':
+    {
+        ret = set_lookup_value <unsigned short> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'd':
+    {
+        ret = set_lookup_value <double> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'f':
+    {
+        ret = set_lookup_value <float> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'x':
+    {
+        ret = set_lookup_value <Id> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    case 'y':
+    {
+        ret = set_lookup_value <ObjId> (target, string(fieldName), value_type_code, key_type_code, key, value);
+        break;
+    }
+    default:
+        ostringstream error;
+        error << "setLookupField: invalid key type " << type_vec[0];
+        PyErr_SetString(PyExc_TypeError, error.str().c_str());
     }
     return ret;
 }// setLookupField
@@ -1340,16 +1598,19 @@ PyDoc_STRVAR(moose_ObjId_setLookupField_documentation,
 
 PyObject * moose_ObjId_setLookupField(_ObjId * self, PyObject * args)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         return NULL;
     }
     PyObject * key;
     PyObject * value;
     char * field;
-    if (!PyArg_ParseTuple(args, "sOO:moose_ObjId_setLookupField", &field,  &key, &value)){
+    if (!PyArg_ParseTuple(args, "sOO:moose_ObjId_setLookupField", &field,  &key, &value))
+    {
         return NULL;
     }
-    if ( setLookupField(self->oid_, field, key, value) == 0){
+    if ( setLookupField(self->oid_, field, key, value) == 0)
+    {
         Py_RETURN_NONE;
     }
     return NULL;
@@ -1367,15 +1628,17 @@ PyDoc_STRVAR(moose_ObjId_setDestField_documentation,
              "The number and type of paramateres depend on the destFinfo to be\n"
              "set. Use moose.doc('{classname}.{fieldname}') to get builtin\n"
              "documentation on the destFinfo `fieldname`\n"
-             );
+            );
 
 PyObject * moose_ObjId_setDestField(_ObjId * self, PyObject * args)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_setDestField");
     }
     PyObject * arglist[10] = {NULL, NULL, NULL, NULL, NULL,
-                              NULL, NULL, NULL, NULL, NULL};
+                              NULL, NULL, NULL, NULL, NULL
+                             };
     ostringstream error;
     ObjId oid = ((_ObjId*)self)->oid_;
 
@@ -1385,7 +1648,8 @@ PyObject * moose_ObjId_setDestField(_ObjId * self, PyObject * args)
                            &arglist[0], &arglist[1], &arglist[2],
                            &arglist[3], &arglist[4], &arglist[5],
                            &arglist[6], &arglist[7], &arglist[8],
-                           &arglist[9])){
+                           &arglist[9]))
+    {
         error << "At most " << maxArgs - 1 << " arguments can be handled.";
         PyErr_SetString(PyExc_ValueError, error.str().c_str());
         return NULL;
@@ -1393,7 +1657,8 @@ PyObject * moose_ObjId_setDestField(_ObjId * self, PyObject * args)
 
     // Get the destFinfo name
     char * fieldName = PyString_AsString(arglist[0]);
-    if (!fieldName){ // not a string, raises TypeError
+    if (!fieldName)  // not a string, raises TypeError
+    {
         error << "first argument must be a string specifying field name.";
         PyErr_SetString(PyExc_TypeError, error.str().c_str());
         return NULL;
@@ -1402,28 +1667,39 @@ PyObject * moose_ObjId_setDestField(_ObjId * self, PyObject * args)
     // Try to parse the arguments.
     vector< string > argType;
     if (parseFinfoType(Field<string>::get(oid, "className"),
-                         "destFinfo", string(fieldName), argType) < 0){
+                       "destFinfo", string(fieldName), argType) < 0)
+    {
         error << "Arguments not handled: " << fieldName << "(";
-        for (unsigned int ii = 0; ii < argType.size(); ++ii){
+        for (unsigned int ii = 0; ii < argType.size(); ++ii)
+        {
             error << argType[ii] << ",";
         }
         error << ")";
         PyErr_SetString(PyExc_TypeError, error.str().c_str());
         return NULL;
     }
-    if (argType.size() == 1){
-        if ( arglist[1] == NULL && argType[0] == "void"){
+    if (argType.size() == 1)
+    {
+        if ( arglist[1] == NULL && argType[0] == "void")
+        {
             bool ret = SetGet0::set(oid, string(fieldName));
-            if (ret){
+            if (ret)
+            {
                 Py_RETURN_TRUE;
-            } else {
+            }
+            else
+            {
                 Py_RETURN_FALSE;
             }
         }
         return setDestFinfo(oid, string(fieldName), arglist[1], argType[0]);
-    } else if (argType.size() == 2){
+    }
+    else if (argType.size() == 2)
+    {
         return setDestFinfo2(oid, string(fieldName), arglist[1], shortType(argType[0]), arglist[2], shortType(argType[1]));
-    } else {
+    }
+    else
+    {
         error << "Can handle only up to 2 arguments" << endl;
         return NULL;
     }
@@ -1436,49 +1712,70 @@ PyObject * setDestFinfo(ObjId obj, string fieldName, PyObject *arg, string argTy
     ostringstream error;
     error << "moose.setDestFinfo: ";
 
-switch (typecode){
-    case 'f': case 'd': {
+    switch (typecode)
+    {
+    case 'f':
+    case 'd':
+    {
         double param = PyFloat_AsDouble(arg);
-        if (typecode == 'f'){
+        if (typecode == 'f')
+        {
             ret = SetGet1<float>::set(obj, fieldName, (float)param);
-        } else {
+        }
+        else
+        {
             ret = SetGet1<double>::set(obj, fieldName, param);
         }
     }
-        break;
-    case 's': {
+    break;
+    case 's':
+    {
         char * param = PyString_AsString(arg);
         ret = SetGet1<string>::set(obj, fieldName, string(param));
     }
-        break;
-    case 'i': case 'l': {
+    break;
+    case 'i':
+    case 'l':
+    {
         long param = PyInt_AsLong(arg);
-        if (param == -1 && PyErr_Occurred()){
+        if (param == -1 && PyErr_Occurred())
+        {
             return NULL;
         }
-        if (typecode == 'i'){
+        if (typecode == 'i')
+        {
             ret = SetGet1<int>::set(obj, fieldName, (int)param);
-        } else {
+        }
+        else
+        {
             ret = SetGet1<long>::set(obj, fieldName, param);
         }
     }
-        break;
-    case 'I': case 'k':{
+    break;
+    case 'I':
+    case 'k':
+    {
         unsigned long param =PyLong_AsUnsignedLong(arg);
-        if (PyErr_Occurred()){
+        if (PyErr_Occurred())
+        {
             return NULL;
         }
-        if (typecode == 'I'){
+        if (typecode == 'I')
+        {
             ret = SetGet1< unsigned int>::set(obj, fieldName, (unsigned int)param);
-        } else {
+        }
+        else
+        {
             ret = SetGet1<unsigned long>::set(obj, fieldName, param);
         }
     }
-        break;
-    case 'x': {
+    break;
+    case 'x':
+    {
         Id param;
         _Id * id = (_Id*)(arg);
-        if (id == NULL){
+        if (id == NULL)
+        {
             error << "argument should be an vec or an melement";
             PyErr_SetString(PyExc_TypeError, error.str().c_str());
             return NULL;
@@ -1486,11 +1783,13 @@ switch (typecode){
         param = id->id_;
         ret = SetGet1<Id>::set(obj, fieldName, param);
     }
-        break;
-    case 'y': {
+    break;
+    case 'y':
+    {
         ObjId param;
         _ObjId * oid = (_ObjId*)(arg);
-        if (oid == NULL){
+        if (oid == NULL)
+        {
             error << "argument should be vec or an melement";
             PyErr_SetString(PyExc_TypeError, error.str().c_str());
             return NULL;
@@ -1498,66 +1797,84 @@ switch (typecode){
         param = oid->oid_;
         ret = SetGet1<ObjId>::set(obj, fieldName, param);
     }
-        break;
-    case 'c': {
+    break;
+    case 'c':
+    {
         char * param = PyString_AsString(arg);
-        if (!param){
+        if (!param)
+        {
             error << "expected argument of type char/string";
             PyErr_SetString(PyExc_TypeError, error.str().c_str());
             return NULL;
-        } else if (strlen(param) == 0){
+        }
+        else if (strlen(param) == 0)
+        {
             error << "Empty string not allowed.";
             PyErr_SetString(PyExc_ValueError, error.str().c_str());
             return NULL;
         }
         ret = SetGet1<char>::set(obj, fieldName, param[0]);
     }
-        break;
-        ////////////////////////////////////////////////////
-        // We do NOT handle multiple vectors. Use the argument
-        // list as a single vector argument.
-        ////////////////////////////////////////////////////
-    case 'v': {
+    break;
+    ////////////////////////////////////////////////////
+    // We do NOT handle multiple vectors. Use the argument
+    // list as a single vector argument.
+    ////////////////////////////////////////////////////
+    case 'v':
+    {
         return _set_vector_destFinfo<int>(obj, string(fieldName), arg, typecode);
     }
-    case 'w': {
+    case 'w':
+    {
         return _set_vector_destFinfo<short>(obj, string(fieldName), arg, typecode);
     }
-    case 'L': {//SET_VECFIELD(long, l) {
+    case 'L':  //SET_VECFIELD(long, l) {
+    {
         return _set_vector_destFinfo<long>(obj, string(fieldName), arg, typecode);
     }
-    case 'N': { //SET_VECFIELD(unsigned int, I)
+    case 'N':   //SET_VECFIELD(unsigned int, I)
+    {
         return _set_vector_destFinfo<unsigned int>(obj, string(fieldName), arg, typecode);
     }
-    case 'K': {//SET_VECFIELD(unsigned long, k)
+    case 'K':  //SET_VECFIELD(unsigned long, k)
+    {
         return _set_vector_destFinfo<unsigned long>(obj, string(fieldName), arg, typecode);
     }
-    case 'F': {//SET_VECFIELD(float, f)
+    case 'F':  //SET_VECFIELD(float, f)
+    {
         return _set_vector_destFinfo<float>(obj, string(fieldName), arg, typecode);
     }
-    case 'D': {//SET_VECFIELD(double, d)
+    case 'D':  //SET_VECFIELD(double, d)
+    {
         return _set_vector_destFinfo<double>(obj, string(fieldName), arg, typecode);
     }
-    case 'S': {
+    case 'S':
+    {
         return _set_vector_destFinfo<string>(obj, string(fieldName), arg, typecode);
     }
-    case 'X': {
+    case 'X':
+    {
         return _set_vector_destFinfo<Id>(obj, string(fieldName), arg, typecode);
     }
-    case 'Y': {
+    case 'Y':
+    {
         return _set_vector_destFinfo<ObjId>(obj, string(fieldName), arg, typecode);
     }
-    default: {
+    default:
+    {
         error << "Cannot handle argument type: " << argType;
         PyErr_SetString(PyExc_TypeError, error.str().c_str());
         return NULL;
     }
-} // switch (shortType(argType[ii])
-if (ret){
-    Py_RETURN_TRUE;
-} else {
-    Py_RETURN_FALSE;
-}
+    } // switch (shortType(argType[ii])
+    if (ret)
+    {
+        Py_RETURN_TRUE;
+    }
+    else
+    {
+        Py_RETURN_FALSE;
+    }
 
 }
 
@@ -1567,53 +1884,74 @@ Set destFinfo for 2 argument destination field functions.
 // template <class A>
 PyObject* setDestFinfo2(ObjId obj, string fieldName, PyObject * arg1, char type1, PyObject * arg2, char type2)
 {
-ostringstream error;
-error << "moose.setDestFinfo2: ";
-switch (type2){
-    case 'f': case 'd': {
+    ostringstream error;
+    error << "moose.setDestFinfo2: ";
+    switch (type2)
+    {
+    case 'f':
+    case 'd':
+    {
         double param = PyFloat_AsDouble(arg2);
-        if (type2 == 'f'){
+        if (type2 == 'f')
+        {
             return setDestFinfo1<float>(obj, fieldName, arg1, type1, (float)param);
-        } else {
+        }
+        else
+        {
             return setDestFinfo1<double>(obj, fieldName, arg1, type1, param);
         }
     }
-    case 's': {
+    case 's':
+    {
         char * param = PyString_AsString(arg2);
         return setDestFinfo1<string>(obj, fieldName, arg1, type1, string(param));
     }
-    case 'i': case 'l': {
+    case 'i':
+    case 'l':
+    {
         long param = PyInt_AsLong(arg2);
-        if (param == -1 && PyErr_Occurred()){
+        if (param == -1 && PyErr_Occurred())
+        {
             return NULL;
         }
-        if (type2 == 'i'){
+        if (type2 == 'i')
+        {
             return setDestFinfo1< int>(obj, fieldName, arg1, type1, (int)param);
-        } else {
+        }
+        else
+        {
             return setDestFinfo1< long>(obj, fieldName, arg1, type1, param);
         }
     }
-    case 'I': case 'k':{
+    case 'I':
+    case 'k':
+    {
         unsigned long param =PyLong_AsUnsignedLong(arg2);
-        if (PyErr_Occurred()){
+        if (PyErr_Occurred())
+        {
             return NULL;
         }
-        if (type2 == 'I'){
+        if (type2 == 'I')
+        {
             return setDestFinfo1< unsigned int>(obj, fieldName, arg1, type1, (unsigned int)param);
-        } else {
+        }
+        else
+        {
             return setDestFinfo1< unsigned long>(obj, fieldName, arg1, type1, param);
         }
     }
-    case 'x': {
+    case 'x':
+    {
         Id param;
         // if (Id_SubtypeCheck(arg)){
-            _Id * id = (_Id*)(arg2);
-            if (id == NULL){
-                error << "argument should be an vec or an melement";
-                PyErr_SetString(PyExc_TypeError, error.str().c_str());
-                return NULL;
-            }
-            param = id->id_;
+        _Id * id = (_Id*)(arg2);
+        if (id == NULL)
+        {
+            error << "argument should be an vec or an melement";
+            PyErr_SetString(PyExc_TypeError, error.str().c_str());
+            return NULL;
+        }
+        param = id->id_;
         // } else if (ObjId_SubtypeCheck(arg)){
         //     _ObjId * oid = (_ObjId*)(arg);
         //     if (oid == NULL){
@@ -1625,7 +1963,8 @@ switch (type2){
         // }
         return setDestFinfo1< Id>(obj, fieldName, arg1, type1, param);
     }
-    case 'y': {
+    case 'y':
+    {
         ObjId param;
         // if (Id_SubtypeCheck(arg)){
         //     _Id * id = (_Id*)(arg);
@@ -1636,35 +1975,41 @@ switch (type2){
         //     }
         //     param = ObjId(id->id_);
         // } else if (ObjId_SubtypeCheck(arg)){
-            _ObjId * oid = (_ObjId*)(arg2);
-            if (oid == NULL){
-                error << "argument should be an vec or an melement";
-                PyErr_SetString(PyExc_TypeError, error.str().c_str());
-                return NULL;
-            }
-            param = oid->oid_;
+        _ObjId * oid = (_ObjId*)(arg2);
+        if (oid == NULL)
+        {
+            error << "argument should be an vec or an melement";
+            PyErr_SetString(PyExc_TypeError, error.str().c_str());
+            return NULL;
+        }
+        param = oid->oid_;
         // }
         return setDestFinfo1< ObjId>(obj, fieldName, arg1, type1, param);
     }
-    case 'c': {
+    case 'c':
+    {
         char * param = PyString_AsString(arg2);
-        if (!param){
+        if (!param)
+        {
             error << "expected argument of type char/string";
             PyErr_SetString(PyExc_TypeError, error.str().c_str());
             return NULL;
-        } else if (strlen(param) == 0){
+        }
+        else if (strlen(param) == 0)
+        {
             error << "Empty string not allowed.";
             PyErr_SetString(PyExc_ValueError, error.str().c_str());
             return NULL;
         }
         return setDestFinfo1< char>(obj, fieldName, arg1, type1, param[0]);
     }
-    default: {
+    default:
+    {
         error << "Unhandled argument 2 type (shortType=" << type2 << ")";
         PyErr_SetString(PyExc_TypeError, error.str().c_str());
         return NULL;
     }
-}
+    }
 }
 
 
@@ -1700,35 +2045,44 @@ PyDoc_STRVAR(moose_ObjId_getFieldNames_documenation,
 // 2011-03-23 15:28:26 (+0530)
 PyObject * moose_ObjId_getFieldNames(_ObjId * self, PyObject *args)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_getFieldNames");
     }
     char * ftype = NULL;
-    if (!PyArg_ParseTuple(args, "|s:moose_ObjId_getFieldNames", &ftype)){
+    if (!PyArg_ParseTuple(args, "|s:moose_ObjId_getFieldNames", &ftype))
+    {
         return NULL;
     }
     string ftype_str = (ftype != NULL)? string(ftype): "";
     vector<string> ret;
     string className = Field<string>::get(self->oid_, "className");
-    if (ftype_str == ""){
-        for (const char **a = getFinfoTypes(); *a; ++a){
+    if (ftype_str == "")
+    {
+        for (const char **a = getFinfoTypes(); *a; ++a)
+        {
             vector<string> fields = getFieldNames(className, string(*a));
             ret.insert(ret.end(), fields.begin(), fields.end());
         }
-    } else {
+    }
+    else
+    {
         ret = getFieldNames(className, ftype_str);
     }
 
     PyObject * pyret = PyTuple_New((Py_ssize_t)ret.size());
 
-    for (unsigned int ii = 0; ii < ret.size(); ++ ii ){
+    for (unsigned int ii = 0; ii < ret.size(); ++ ii )
+    {
         PyObject * fname = Py_BuildValue("s", ret[ii].c_str());
-        if (!fname){
+        if (!fname)
+        {
             Py_XDECREF(pyret);
             pyret = NULL;
             break;
         }
-        if (PyTuple_SetItem(pyret, (Py_ssize_t)ii, fname)){
+        if (PyTuple_SetItem(pyret, (Py_ssize_t)ii, fname))
+        {
             Py_XDECREF(pyret);
             // Py_DECREF(fname);
             pyret = NULL;
@@ -1756,20 +2110,24 @@ PyDoc_STRVAR(moose_ObjId_getNeighbors_documentation,
 
 PyObject * moose_ObjId_getNeighbors(_ObjId * self, PyObject * args)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_getNeighbors");
     }
     char * field = NULL;
-    if (!PyArg_ParseTuple(args, "s:moose_ObjId_getNeighbors", &field)){
+    if (!PyArg_ParseTuple(args, "s:moose_ObjId_getNeighbors", &field))
+    {
         return NULL;
     }
     vector< Id > val = LookupField< string, vector< Id > >::get(self->oid_, "neighbors", string(field));
 
     PyObject * ret = PyTuple_New((Py_ssize_t)val.size());
 
-    for (unsigned int ii = 0; ii < val.size(); ++ ii ){
+    for (unsigned int ii = 0; ii < val.size(); ++ ii )
+    {
         _Id * entry = PyObject_New(_Id, &IdType);
-        if (!entry || PyTuple_SetItem(ret, (Py_ssize_t)ii, (PyObject*)entry)){
+        if (!entry || PyTuple_SetItem(ret, (Py_ssize_t)ii, (PyObject*)entry))
+        {
             Py_DECREF(ret);
             // Py_DECREF((PyObject*)entry);
             ret = NULL;
@@ -1832,10 +2190,11 @@ PyDoc_STRVAR(moose_ObjId_connect_documentation,
              "--------\n"
              "moose.connect\n"
              "\n"
-             );
+            );
 PyObject * moose_ObjId_connect(_ObjId * self, PyObject * args)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_connect");
     }
     extern PyTypeObject ObjIdType;
@@ -1847,10 +2206,12 @@ PyObject * moose_ObjId_connect(_ObjId * self, PyObject * args)
                          &srcField,
                          &destPtr,
                          &destField,
-                         &msgType)){
+                         &msgType))
+    {
         return NULL;
     }
-    if (msgType == NULL){
+    if (msgType == NULL)
+    {
         msgType = default_msg_type;
     }
     _ObjId * dest = reinterpret_cast<_ObjId*>(destPtr);
@@ -1859,7 +2220,8 @@ PyObject * moose_ObjId_connect(_ObjId * self, PyObject * args)
                                    string(srcField),
                                    dest->oid_,
                                    string(destField));
-    if (mid.bad()){
+    if (mid.bad())
+    {
         PyErr_SetString(PyExc_NameError,
                         "connect failed: check field names and type compatibility.");
         return NULL;
@@ -1877,46 +2239,63 @@ PyDoc_STRVAR(moose_ObjId_richcompare_documentation,
              "meaningful for elements.\n");
 PyObject* moose_ObjId_richcompare(_ObjId * self, PyObject * other, int op)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_richcompare");
     }
     extern PyTypeObject ObjIdType;
-    if ((self != NULL && other == NULL) || (self == NULL && other != NULL)){
-        if (op == Py_EQ){
+    if ((self != NULL && other == NULL) || (self == NULL && other != NULL))
+    {
+        if (op == Py_EQ)
+        {
             Py_RETURN_FALSE;
-        } else if (op == Py_NE){
+        }
+        else if (op == Py_NE)
+        {
             Py_RETURN_TRUE;
-        } else {
+        }
+        else
+        {
             PyErr_SetString(PyExc_TypeError, "Cannot compare NULL with non-NULL");
             return NULL;
         }
     }
-    if (!PyObject_IsInstance(other, (PyObject*)&ObjIdType)){
+    if (!PyObject_IsInstance(other, (PyObject*)&ObjIdType))
+    {
         ostringstream error;
         error << "Cannot compare ObjId with "
               << Py_TYPE(other)->tp_name;
         PyErr_SetString(PyExc_TypeError, error.str().c_str());
         return NULL;
     }
-    if (!Id::isValid(((_ObjId*)other)->oid_.id)){
+    if (!Id::isValid(((_ObjId*)other)->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_richcompare");
     }
 
     string l_path = self->oid_.path();
     string r_path = ((_ObjId*)other)->oid_.path();
     int result = l_path.compare(r_path);
-    if (result == 0){
-        if (op == Py_EQ || op == Py_LE || op == Py_GE){
+    if (result == 0)
+    {
+        if (op == Py_EQ || op == Py_LE || op == Py_GE)
+        {
             Py_RETURN_TRUE;
         }
         Py_RETURN_FALSE;
-    } else if (result < 0){
-        if (op == Py_LT || op == Py_LE || op == Py_NE){
+    }
+    else if (result < 0)
+    {
+        if (op == Py_LT || op == Py_LE || op == Py_NE)
+        {
             Py_RETURN_TRUE;
         }
         Py_RETURN_FALSE;
-    } else {
-        if (op == Py_GT || op == Py_GE || op == Py_NE){
+    }
+    else
+    {
+        if (op == Py_GT || op == Py_GE || op == Py_NE)
+        {
             Py_RETURN_TRUE;
         }
         Py_RETURN_FALSE;
@@ -1933,10 +2312,11 @@ PyDoc_STRVAR(moose_ObjId_getDataIndex_documentation,
              "        >>> comp.getDataIndex()\n"
              "        >>> 0\n"
              ""
-             );
+            );
 PyObject * moose_ObjId_getDataIndex(_ObjId * self)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_getDataIndex");
     }
     PyObject * ret = Py_BuildValue("I", self->oid_.dataIndex);
@@ -1948,7 +2328,8 @@ PyObject * moose_ObjId_getDataIndex(_ObjId * self)
 // place-holer to avoid compilation errors.
 PyObject * moose_ObjId_getFieldIndex(_ObjId * self)
 {
-    if (!Id::isValid(self->oid_.id)){
+    if (!Id::isValid(self->oid_.id))
+    {
         RAISE_INVALID_ID(NULL, "moose_ObjId_getFieldIndex");
     }
     PyObject * ret = Py_BuildValue("I", self->oid_.dataIndex);
@@ -1959,34 +2340,61 @@ PyObject * moose_ObjId_getFieldIndex(_ObjId * self)
 // Python method lists for PyObject of ObjId
 ///////////////////////////////////////////////
 
-static PyMethodDef ObjIdMethods[] = {
-    {"getFieldType", (PyCFunction)moose_ObjId_getFieldType, METH_VARARGS,
-     moose_ObjId_getFieldType_documentation},
-    {"getField", (PyCFunction)moose_ObjId_getField, METH_VARARGS,
-     moose_ObjId_getField_documentation},
-    {"setField", (PyCFunction)moose_ObjId_setField, METH_VARARGS,
-     moose_ObjId_setField_documentation},
-    {"getLookupField", (PyCFunction)moose_ObjId_getLookupField, METH_VARARGS,
-     moose_ObjId_getLookupField_documentation},
-    {"setLookupField", (PyCFunction)moose_ObjId_setLookupField, METH_VARARGS,
-     moose_ObjId_setLookupField_documentation},
-    {"getId", (PyCFunction)moose_ObjId_getId, METH_NOARGS,
-     moose_ObjId_getId_documentation},
-    {"vec", (PyCFunction)moose_ObjId_getId, METH_NOARGS,
-     "Return the vec this element belongs to. This is overridden by the"
-     " attribute of the same name for quick access."},
-    {"getFieldNames", (PyCFunction)moose_ObjId_getFieldNames, METH_VARARGS,
-     moose_ObjId_getFieldNames_documenation},
-    {"getNeighbors", (PyCFunction)moose_ObjId_getNeighbors, METH_VARARGS,
-     moose_ObjId_getNeighbors_documentation},
-    {"connect", (PyCFunction)moose_ObjId_connect, METH_VARARGS,
-     moose_ObjId_connect_documentation},
-    {"getDataIndex", (PyCFunction)moose_ObjId_getDataIndex, METH_NOARGS,
-     moose_ObjId_getDataIndex_documentation},
-    {"getFieldIndex", (PyCFunction)moose_ObjId_getFieldIndex, METH_NOARGS,
-     "Get the index of this object as a field."},
-    {"setDestField", (PyCFunction)moose_ObjId_setDestField, METH_VARARGS,
-     moose_ObjId_setDestField_documentation},
+static PyMethodDef ObjIdMethods[] =
+{
+    {
+        "getFieldType", (PyCFunction)moose_ObjId_getFieldType, METH_VARARGS,
+        moose_ObjId_getFieldType_documentation
+    },
+    {
+        "getField", (PyCFunction)moose_ObjId_getField, METH_VARARGS,
+        moose_ObjId_getField_documentation
+    },
+    {
+        "setField", (PyCFunction)moose_ObjId_setField, METH_VARARGS,
+        moose_ObjId_setField_documentation
+    },
+    {
+        "getLookupField", (PyCFunction)moose_ObjId_getLookupField, METH_VARARGS,
+        moose_ObjId_getLookupField_documentation
+    },
+    {
+        "setLookupField", (PyCFunction)moose_ObjId_setLookupField, METH_VARARGS,
+        moose_ObjId_setLookupField_documentation
+    },
+    {
+        "getId", (PyCFunction)moose_ObjId_getId, METH_NOARGS,
+        moose_ObjId_getId_documentation
+    },
+    {
+        "vec", (PyCFunction)moose_ObjId_getId, METH_NOARGS,
+        "Return the vec this element belongs to. This is overridden by the"
+        " attribute of the same name for quick access."
+    },
+    {
+        "getFieldNames", (PyCFunction)moose_ObjId_getFieldNames, METH_VARARGS,
+        moose_ObjId_getFieldNames_documenation
+    },
+    {
+        "getNeighbors", (PyCFunction)moose_ObjId_getNeighbors, METH_VARARGS,
+        moose_ObjId_getNeighbors_documentation
+    },
+    {
+        "connect", (PyCFunction)moose_ObjId_connect, METH_VARARGS,
+        moose_ObjId_connect_documentation
+    },
+    {
+        "getDataIndex", (PyCFunction)moose_ObjId_getDataIndex, METH_NOARGS,
+        moose_ObjId_getDataIndex_documentation
+    },
+    {
+        "getFieldIndex", (PyCFunction)moose_ObjId_getFieldIndex, METH_NOARGS,
+        "Get the index of this object as a field."
+    },
+    {
+        "setDestField", (PyCFunction)moose_ObjId_setDestField, METH_VARARGS,
+        moose_ObjId_setDestField_documentation
+    },
     {NULL, NULL, 0, NULL},        /* Sentinel */
 };
 
@@ -2049,9 +2457,10 @@ PyDoc_STRVAR(moose_ObjId_documentation,
              ">>> a = Neutral('alpha') # Creates element named `alpha` under current working element\n"
              ">>> b = Neutral('alpha/beta') # Creates the element named `beta` under `alpha`\n"
              ">>> c = moose.melement(b)"
-             );
+            );
 
-PyTypeObject ObjIdType = {
+PyTypeObject ObjIdType =
+{
     PyVarObject_HEAD_INIT(NULL, 0)            /* tp_head */
     "moose.melement",                      /* tp_name */
     sizeof(_ObjId),                     /* tp_basicsize */

--- a/pymoose/moosemodule.cpp
+++ b/pymoose/moosemodule.cpp
@@ -1,38 +1,10 @@
 // moosemodule.cpp ---
-//
-// Filename: moosemodule.cpp
-// Description:
-// Author: Subhasis Ray
-// Maintainer:
-// Copyright (C) 2010 Subhasis Ray, all rights reserved.
-// Created: Thu Mar 10 11:26:00 2011 (+0530)
-// Version:
-// Last-Updated: Mon 25 Apr 2016 11:17:24 AM IST
-//           By: Dilawar Singh
-//
-
-// Change log:
-//
-// 2011-03-10 Initial version. Starting coding directly with Python
-//            API.  Trying out direct access to Python API instead of
-//            going via SWIG. SWIG has this issue of creating huge
-//            files and the resulting binaries are also very
-//            large. Since we are not going to use any language but
-//            Python in the foreseeable future, we can avoid the bloat
-//            by coding directly with Python API.
-//
-// 2012-01-05 Much polished version. Handling destFinfos as methods in
-//            Python class.
-//
-// 2012-04-13 Finished reimplementing the meta class system using
-//            Python/C API.
-//            Decided not to expose any lower level moose API.
-//
-// 2012-04-20 Finalized the C interface
+// For detailed log, see the git-log .
+// Author : Subhasis Ray
+// Maintainer : Dilawar Singh, Subhasis Ray
 
 #include <Python.h>
-
-#include <structmember.h> // This defines the type id macros like T_STRING
+#include <structmember.h>
 
 #ifdef USE_NUMPY
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
@@ -2879,6 +2851,7 @@ PyObject * moose_ObjId_get_elementField_attr(PyObject * self,
     Py_INCREF(self); // compensate for stolen ref
     PyTuple_SetItem(args, 1, PyString_FromString(name));
     _Field * ret = PyObject_New(_Field, &moose_ElementField);
+
     // 2. Now use this arg to actually create the element field.
     if (moose_ElementField.tp_init((PyObject*)ret, args, NULL) != 0)
     {

--- a/pymoose/vec.cpp
+++ b/pymoose/vec.cpp
@@ -441,14 +441,10 @@ int moose_Id_init(_Id * self, PyObject * args, PyObject * kwargs)
        [unsigned int isGlobal] - default: 0
        [string type] - default: Neutral
     */
-    if (PyArg_ParseTupleAndKeywords(args,
-                                    kwargs,
-                                    "s|IIs:moose_Id_init",
-                                    kwlist,
-                                    &path,
-                                    &numData,
-                                    &isGlobal,
-                                    &type))
+    if (PyArg_ParseTupleAndKeywords(args, kwargs, "s|IIs:moose_Id_init",
+                                    kwlist, &path, &numData, &isGlobal,
+                                    &type)
+            )
     {
         // Parsing args successful, if any error happens now,
         // different argument processing will not help. Return error
@@ -462,10 +458,9 @@ int moose_Id_init(_Id * self, PyObject * args, PyObject * kwargs)
             return -1;
         }
         self->id_ = Id(trimmed_path);
+
         // Return already existing object
-        if (self->id_ != Id() ||
-                trimmed_path == "/" ||
-                trimmed_path == "/root")
+        if (self->id_ != Id() || trimmed_path == "/" || trimmed_path == "/root")
         {
             if ((numData > 0) && (numData != Field<unsigned int>::get(self->id_, "numData")))
             {
@@ -474,13 +469,10 @@ int moose_Id_init(_Id * self, PyObject * args, PyObject * kwargs)
             return 0;
         }
         if (type == NULL)
-        {
             type = _default_type;
-        }
         if (numData <= 0)
-        {
             numData = 1;
-        }
+
         self->id_ = create_Id_from_path(trimmed_path, numData, isGlobal, type);
         if (self->id_ == Id() && PyErr_Occurred())
         {

--- a/shell/Shell.cpp
+++ b/shell/Shell.cpp
@@ -212,13 +212,17 @@ Id Shell::doCreate( string type, ObjId parent, string name,
             warning( ss.str() );
             return Id();
         }
+
+        // TODO: This should be an error in future.
+        // This logic of handling already existing path is now handled in
+        // melements.cpp . Calling this section should become an error in
+        // future.
         if ( Neutral::child( parent.eref(), name ) != Id() )
         {
             stringstream ss;
-            ss << "Shell::doCreate: Object with same name already present: '"
-               << parent.path() << "/" << name << "'. No Element created";
-            cout << "Warn: " << ss.str( ) << endl;
-            warning( ss.str() );
+            ss << "Object with same path already present : " << parent.path()
+                << "/" << name;
+            moose::showWarn( ss.str() );
             return Id();
         }
         // Get the new Id ahead of time and pass to all nodes.

--- a/shell/Shell.cpp
+++ b/shell/Shell.cpp
@@ -163,39 +163,6 @@ Shell::~Shell()
     ;
 }
 
-#ifdef  CYMOOSE
-
-/*-----------------------------------------------------------------------------
- *  This function must create a fully functional Shell. Used in cython
- *  interface.
- *-----------------------------------------------------------------------------*/
-Shell* Shell::initShell()
-{
-    Eref sheller = Id().eref();
-    Shell* shell = reinterpret_cast< Shell* >( sheller.data() );
-    return shell;
-}
-
-Id Shell::create(string type, string name, unsigned int numData
-                 , NodePolicy nodePolicy, unsigned int preferredNode
-                )
-{
-    if(name.size() == 0)
-        return doCreate(type, Id(), name, numData, nodePolicy, preferredNode);
-
-    string::size_type pos = name.find_last_of('/');
-    string parentPath = name.substr(0, pos);
-    ObjId parentObj = ObjId(parentPath);
-    //cerr << "info: Creating Obj with parent : " << parentObj << endl;
-    Id id = doCreate(type, parentObj, name.substr(pos+1)
-                     , numData, nodePolicy, preferredNode
-                    );
-    //cerr << "    ++ with id " << id << endl;
-    return id;
-}
-
-#endif     /* -----  CYMOOSE  ----- */
-
 void Shell::setShellElement( Element* shelle )
 {
     shelle_ = shelle;
@@ -250,6 +217,7 @@ Id Shell::doCreate( string type, ObjId parent, string name,
             stringstream ss;
             ss << "Shell::doCreate: Object with same name already present: '"
                << parent.path() << "/" << name << "'. No Element created";
+            cout << "Warn: " << ss.str( ) << endl;
             warning( ss.str() );
             return Id();
         }
@@ -269,6 +237,7 @@ Id Shell::doCreate( string type, ObjId parent, string name,
             nb,			// Node balance configuration
             parentMsgIndex	// Message index of child-parent msg.
         );
+
         // innerCreate( type, parent, ret, name, numData, isGlobal );
 
         return ret;
@@ -1027,7 +996,7 @@ bool Shell::keepLooping()
 
 void Shell::warning( const string& text )
 {
-    LOG( moose::warning, text  );
+    moose::showWarn( text  );
 }
 
 void Shell::error( const string& text )

--- a/tests/python/test_accessing_existing_paths.py
+++ b/tests/python/test_accessing_existing_paths.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import moose
+import re
+
+def fixPath(path):
+    path = re.sub(r'/+', '/', path)
+    return path
+
+paths = [ '/a'
+        , '//a'
+        , '/a/b'
+        , '/a/b/'
+        , '//a//b/////'
+        , '/a/./b'
+        , '///a/././b'
+        ]
+expectedPath = [fixPath(p) for p in paths]
+
+expectedChanges = zip(paths, expectedPath)
+
+for p in expectedPath:
+    print( 'Accessing %s' % p )
+    try:
+        moose.Neutral(p)
+    except Exception as e:
+        print( 'Same path access by element' )
+        moose.element( p )
+
+foundPath = []
+for p in moose.wildcardFind('/##'):
+    if "/a" in p.path:
+       foundPath.append(p.path)
+
+testFailed = False
+for f in foundPath:
+    f = re.sub(r'\[\d+\]', '', f)
+    if f not in expectedPath:
+        testFailed = True
+
+if testFailed:
+    print("Test failed on paths")

--- a/tests/python/test_paths.py
+++ b/tests/python/test_paths.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import moose
+import re
+
+def fixPath(path):
+    path = re.sub(r'/+', '/', path)
+    return path
+
+paths = [ '/a'
+        , '//a'
+        , '/a/b'
+        , '/a/b/'
+        , '//a//b/////'
+        , '/a/./b'
+        , '///a/././b'
+        ]
+expectedPath = [fixPath(p) for p in paths]
+
+expectedChanges = zip(paths, expectedPath)
+
+for p in expectedPath:
+    print( 'Accessing %s' % p )
+    try:
+        moose.Neutral(p)
+    except Exception as e:
+        print( 'Same path access by element' )
+        moose.element( p )
+
+foundPath = []
+for p in moose.wildcardFind('/##'):
+    if "/a" in p.path:
+       foundPath.append(p.path)
+
+testFailed = False
+for f in foundPath:
+    f = re.sub(r'\[\d+\]', '', f)
+    if f not in expectedPath:
+        testFailed = True
+
+if testFailed:
+    print("Test failed on paths")
+
+a = moose.Neutral( '/k' )
+b = moose.Neutral( '/k' )
+h = moose.HSolve( '/h' )
+try:
+    h = moose.Neutral( '/h' )
+    print( 'This should have failed' )
+    quit(1)
+except Exception as e:
+    print( 'Success' )

--- a/tests/python/test_sbml.py
+++ b/tests/python/test_sbml.py
@@ -18,14 +18,16 @@ import os
 import moose
 import moose.utils as mu
 
+print( 'Using moose form %s' % moose.__file__ )
+print( '\t Moose version %s' % moose.version( ) )
+
 # the model lives in the same directory as the test script
 modeldir = os.path.dirname( os.path.realpath( __file__ ) )
 
 def main():
     modelname = os.path.join(modeldir, './chem_models/00001-sbml-l3v1.xml' )
     model = moose.mooseReadSBML( modelname, '/sbml' )
-    print( model )
-    c = moose.Clock('/clock')
+    c = moose.element('/clock')
     moose.reinit()
     moose.start(200)
     check(  )

--- a/tests/python/test_warnigns.py
+++ b/tests/python/test_warnigns.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import moose
+print( 'Using moose from %s' % moose.__file__ )
+a = moose.Neutral( '/a' )
+b = moose.Ksolve( '/a/k' )
+
+try:
+    c = moose.Ksolve( '/a/k' )
+    d = moose.Neutral( '/a' )
+    d = moose.Neutral( '/a' )
+    quit(-1)
+except Exception as e:
+    c = moose.element( '/a/k' )
+    quit( 0 )

--- a/utility/print_function.hpp
+++ b/utility/print_function.hpp
@@ -195,6 +195,7 @@ namespace moose {
         if(!reset)
             ss << T_RESET;
         cout << ss.str() << endl;
+        cout.flush( );
     }
 
     /*


### PR DESCRIPTION
- When path `/a/b` exists with type `moose.A`, accessing it with `moose.B('/a/b')` is an error.
- When path '/a/b' exists with type `moose.A' , accessing it with `moose.A('/a/b')` ~is a user warning~ is a DeprecationWarning. In future, it will be an error.