### PR TITLE
SeqSynHandler fixes - normalized seqActivation by dt

### DIFF
--- a/synapse/SeqSynHandler.cpp
+++ b/synapse/SeqSynHandler.cpp
@@ -553,7 +553,7 @@ void SeqSynHandler::vProcess( const Eref& e, ProcPtr p )
 					seqActivation_ += pow( *y, sequencePower_ );
 
 				// We'll use the seqActivation_ to send a special msg.
-				seqActivation_ *= sequenceScale_;
+				seqActivation_ *= sequenceScale_ / p->dt;
 			}
 			if ( plasticityScale_ > 0.0 ) { // Short term changes in individual wts
 				weightScaleVec_ = correlVec;


### PR DESCRIPTION
Since the input is an impulse, the amplitude has been normalized by dt. The basal response was already taking care of this, but the sequence response wasn't. It was now been fixed.