### PR TITLE
Rate law unit are further cleaned up

### DIFF
--- a/python/moose/SBML/writeSBML.py
+++ b/python/moose/SBML/writeSBML.py
@@ -157,7 +157,8 @@ def mooseWriteSBML(modelpath, filename, sceneitems={}):
             return True, consistencyMessages, writeTofile
 
         if (not SBMLok):
-            cerr << "Errors encountered " << endl
+            #cerr << "Errors encountered " << endl
+            consistencyMessages = "Errors encountered"
             return -1, consistencyMessages
     else:
         return False, "Atleast one compartment should exist to write SBML"

--- a/python/moose/genesis/writeKkit.py
+++ b/python/moose/genesis/writeKkit.py
@@ -141,7 +141,7 @@ def mooseWriteKkit( modelpath, filename, sceneitems={}):
             print('Written to file '+filename)
             return errors, True
         else:
-            print(("Warning: writeKkit:: No model found on " , modelpath))
+            print("Warning: writeKkit:: No model found on " , modelpath)
             return False
 
 def findMinMax(sceneitems):
@@ -356,7 +356,7 @@ def trimPath(mobj):
         mobj = moose.element(mobj.parent)
         found = True
     if mobj.path == "/":
-        print((original, " object doesn't have compartment as a parent "))
+        print(original, " object doesn't have compartment as a parent ")
         return
     #other than the kinetics compartment, all the othername are converted to group in Genesis which are place under /kinetics
     # Any moose object comes under /kinetics then one level down the path is taken.
@@ -737,6 +737,6 @@ if __name__ == "__main__":
     written = mooseWriteKkit('/'+modelpath,output)
 
     if written:
-            print((" file written to ",output))
+            print(" file written to ",output)
     else:
             print(" could be written to kkit format")


### PR DESCRIPTION
readSBML: explicitly ratio is set to 4, so that e2,e1 is balanced, If units are defined in the rate law for the reaction then checks are made and if not in milli mole the base unit then recalculate, spell correction.

writeSBML: instead of printing error msg, saving into string for later use
writekkit : instead of printing error msg, saving into string for later use