### PR TITLE
retracting seqActivation normalization by dt to restore time-step invariance

### DIFF
--- a/synapse/SeqSynHandler.cpp
+++ b/synapse/SeqSynHandler.cpp
@@ -553,7 +553,7 @@ void SeqSynHandler::vProcess( const Eref& e, ProcPtr p )
 					seqActivation_ += pow( *y, sequencePower_ );
 
 				// We'll use the seqActivation_ to send a special msg.
-				seqActivation_ *= sequenceScale_ / p->dt;
+				seqActivation_ *= sequenceScale_;
 			}
 			if ( plasticityScale_ > 0.0 ) { // Short term changes in individual wts
 				weightScaleVec_ = correlVec;


### PR DESCRIPTION
retracting seqActivation normalization by dt to restore time-step invariance