### PR TITLE
Fixes to BhallaLab/moose#224 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,9 +408,12 @@ message( STATUS "Platform ${_platform_desc}" )
 
 set(EXTRA_ARGS "--prefix ${CMAKE_INSTALL_PREFIX}")
 
-if( ${_platform_desc} MATCHES ".*(Ubuntu|Debian).*" )
-    list( APPEND EXTRA_ARGS "--install-layout=deb" )
-endif( )
+## NOTE: Disable it here. It must be handled by moose repository CMakeLists.txt
+## which is used in created packages. For normal user, it should install in
+## site-packages.
+#if( ${_platform_desc} MATCHES ".*(Ubuntu|Debian).*" )
+#    list( APPEND EXTRA_ARGS "--install-layout=deb" )
+#endif( )
 
 # If make is called with sudo, install in system directories. Otherwise use
 # --user to install in user home.

--- a/python/setup.cmake.py
+++ b/python/setup.cmake.py
@@ -18,34 +18,11 @@ __status__           = "Development"
 
 import os
 import sys
-import site
-
-# if uid is zero then install in root paths. Else install it in user path.
-#print( '[INFO] Overwriting --prefix ' )
-#prefixLoc = sys.argv.index( '--prefix' )
-#prefix = sys.argv[ prefixLoc + 1 ]
-#if '/usr/' in prefix:
-#    try:
-#        prefixLoc = sys.argv.index( '--prefix' )
-#        del sys.argv[ prefixLoc ]
-#        del sys.argv[ prefixLoc ]
-#    except Exception as e:
-#        pass
-#
-#    uid = os.getuid( )
-#    if uid == 0:
-#        # Here comes the root.
-#        print( '   called by sudo' )
-#        sys.argv += [ '--prefix', '/usr' ]
-#    else:
-#        sys.argv += [ '--prefix', site.getuserbase( ) ]
-#
 
 from distutils.core import setup
-
 script_dir = os.path.dirname( os.path.abspath( __file__ ) )
-
 version = '3.2.git'
+
 try:
     with open( os.path.join( script_dir, '..', 'VERSION'), 'r' ) as f:
         version = f.read( )

--- a/python/setup.cmake.py
+++ b/python/setup.cmake.py
@@ -21,24 +21,25 @@ import sys
 import site
 
 # if uid is zero then install in root paths. Else install it in user path.
-
-print( '[INFO] Overwriting --prefix ' )
-try:
-    prefixLoc = sys.argv.index( '--prefix' )
-    del sys.argv[ prefixLoc ]
-    del sys.argv[ prefixLoc ]
-except Exception as e:
-    pass
-
-uid = os.getuid( )
-if uid == 0:
-    # Here comes the root.
-    print( '   called by sudo' )
-    sys.argv += [ '--prefix', '/usr' ]
-else:
-    sys.argv += [ '--prefix', site.getuserbase( ) ]
-
-print( sys.argv )
+#print( '[INFO] Overwriting --prefix ' )
+#prefixLoc = sys.argv.index( '--prefix' )
+#prefix = sys.argv[ prefixLoc + 1 ]
+#if '/usr/' in prefix:
+#    try:
+#        prefixLoc = sys.argv.index( '--prefix' )
+#        del sys.argv[ prefixLoc ]
+#        del sys.argv[ prefixLoc ]
+#    except Exception as e:
+#        pass
+#
+#    uid = os.getuid( )
+#    if uid == 0:
+#        # Here comes the root.
+#        print( '   called by sudo' )
+#        sys.argv += [ '--prefix', '/usr' ]
+#    else:
+#        sys.argv += [ '--prefix', site.getuserbase( ) ]
+#
 
 from distutils.core import setup
 


### PR DESCRIPTION
Debian related macros are be moved to BhallaLab/moose.
`moose-core` is not python module independant of 'debian' specific install paths. 
