### PR TITLE
Updates for multiscale modeling

### DIFF
--- a/basecode/Id.h
+++ b/basecode/Id.h
@@ -174,4 +174,13 @@ private:
     static vector< Element* >& elements();
 };
 
+namespace std {
+	template <> class hash<Id>{
+			public :
+			size_t operator()(const Id &x ) const{
+			return hash<unsigned int>()( x.value() );
+		}
+	};
+}
+
 #endif // _ID_H

--- a/basecode/header.h
+++ b/basecode/header.h
@@ -16,6 +16,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <unordered_map>
 #include <iostream>
 #include <sstream>
 #include <typeinfo> // used in Conv.h to extract compiler independent typeid

--- a/biophysics/CompartmentBase.cpp
+++ b/biophysics/CompartmentBase.cpp
@@ -636,6 +636,15 @@ void CompartmentBase::displace( double dx, double dy, double dz )
 	z_ += dz;
 }
 
+static bool hasScaleFormula( const Eref& e ) {
+	vector< Id > kids;
+	Neutral::children( e, kids );
+	for ( vector< Id >::iterator j = kids.begin(); j != kids.end(); j++ )
+		if ( j->element()->getName() == "scaleFormula" )
+			return true;
+	return false;
+}
+
 void CompartmentBase::setGeomAndElec( const Eref& e,
 				double len, double dia )
 {
@@ -650,6 +659,8 @@ void CompartmentBase::setGeomAndElec( const Eref& e,
 		vector< ObjId > chans;
 		allChildren( e.objId(), ALLDATA, "ISA=ChanBase", chans );
 		for ( unsigned int i = 0; i < chans.size(); ++i ) {
+			if ( hasScaleFormula( chans[i].eref() ) )
+				continue; // Later we will eval the formula with len and dia
 			double gbar = Field< double >::get( chans[i], "Gbar" );
 			gbar *= len * dia / ( length_ * diameter_ );
 			Field< double >::set( chans[i], "Gbar", gbar );

--- a/biophysics/Neuron.cpp
+++ b/biophysics/Neuron.cpp
@@ -1111,6 +1111,7 @@ void Neuron::buildElist( const Eref& e,
     ObjId oldCwe = shell->getCwe();
     shell->setCwe( e.objId() );
     wildcardFind( path, elist );
+	sort( elist.begin(), elist.end() );
     shell->setCwe( oldCwe );
     evalExprForElist( elist, expr, val );
 }
@@ -1285,6 +1286,8 @@ static void fillSegments( vector< SwcSegment >& segs,
                     comptType = 3; // generic dendrite
                 }
             }
+			// cout << "Seg[" << i << "].xy = " << int(x*1e6) << " " << int(y*1e6) << endl;
+
             segs.push_back(
                 SwcSegment( i, comptType, x, y, z, dia/2.0, paIndex ) );
         }
@@ -1347,6 +1350,7 @@ void Neuron::buildSegmentTree( const Eref& e )
 {
     vector< Id > kids;
     Neutral::children( e, kids );
+	sort( kids.begin(), kids.end() );
 
     soma_ = fillSegIndex( kids, segIndex_ );
     if ( kids.size() == 0 || soma_ == Id() )

--- a/mesh/NeuroMesh.cpp
+++ b/mesh/NeuroMesh.cpp
@@ -648,6 +648,7 @@ void NeuroMesh::updateShaftParents()
 // Uses all compartments, and if they have spines on them adds those too.
 void NeuroMesh::setSubTree( const Eref& e, vector< ObjId > compts )
 {
+    sort( compts.begin(), compts.end() );
     if ( separateSpines_ )
     {
         NeuroNode::buildSpinyTree( compts, nodes_, shaft_, head_, parent_);

--- a/mesh/NeuroNode.h
+++ b/mesh/NeuroNode.h
@@ -165,7 +165,7 @@ class NeuroNode: public CylBase
 					vector< unsigned int >& spineParent );
 		void setParentAndChildren( unsigned int index, int dendParent,
 				vector< NeuroNode >& nodes,
-				const map< Id, unsigned int >& dendMap );
+				const unordered_map< Id, unsigned int >& dendMap );
 
 		/**
 		 * Trims off all spines from tree. Does so by identifying a set of

--- a/mesh/SpineMesh.cpp
+++ b/mesh/SpineMesh.cpp
@@ -260,6 +260,7 @@ void SpineMesh::handleSpineList(
 		vector< unsigned int > index( head.size(), 0 );
 		for ( unsigned int i = 0; i < head.size(); ++i ) {
 			spines_[i] = SpineEntry( shaft[i], head[i], parentVoxel[i] );
+			// cout << i << "	" << head[i] << ", pa = " << parentVoxel[i] << endl;
 			// ret = spines_[i].psdCoords();
 			// assert( ret.size() == 8 );
 			// psdCoords.insert( psdCoords.end(), ret.begin(), ret.end() );

--- a/python/rdesigneur/rdesigneur.py
+++ b/python/rdesigneur/rdesigneur.py
@@ -527,9 +527,14 @@ class rdesigneur:
             cc = moose.element( self.modelPath + '/chem/' + chemCompt)
             voxelVec = []
             temp = [ self._makeUniqueNameStr( i ) for i in comptList ]
+            #print( temp )
+            #print( "#####################" )
             comptSet = set( temp )
             #em = [ moose.element(i) for i in cc.elecComptMap ]
-            em = [ self._makeUniqueNameStr(i) for i in cc.elecComptMap ]
+            em = sorted( [ self._makeUniqueNameStr(i[0]) for i in cc.elecComptMap ] )
+            #print( em )
+            #print( "=================================================" )
+
             voxelVec = [i for i in range(len( em ) ) if em[i] in comptSet ]
             # Here we collapse the voxelVec into objects to plot.
             allObj = moose.vec( self.modelPath + '/chem/' + plotSpec[2] )
@@ -574,6 +579,7 @@ class rdesigneur:
             assert( plotField == plotField2 )
             plotObj3 = plotObj + plotObj2
             numPlots = sum( q != dummy for q in plotObj3 )
+            #print( "PlotList: {0}: numobj={1}, field ={2}, nd={3}, ns={4}".format( pair, numPlots, plotField, len( dendCompts ), len( spineCompts ) ) )
             if numPlots > 0:
                 tabname = graphs.path + '/plot' + str(k)
                 scale = knownFields[i[3]][2]
@@ -911,7 +917,6 @@ class rdesigneur:
     ################################################################
     # Utility function for setting up clocks.
     def _configureClocks( self ):
-        t0 = time.time()
         if self.turnOffElec:
             elecDt = 1e6
             elecPlotDt = 1e6
@@ -920,21 +925,16 @@ class rdesigneur:
             elecPlotDt = self.elecPlotDt
         diffDt = self.diffDt
         chemDt = self.chemDt
-        print( "t1 = {}".format( time.time() - t0 ) )
         for i in range( 0, 9 ):
             moose.setClock( i, elecDt )
         moose.setClock( 8, elecPlotDt )
         moose.setClock( 10, diffDt )
-        print( "t2 = {}".format( time.time() - t0 ) )
         for i in range( 11, 18 ):
             moose.setClock( i, chemDt )
         moose.setClock( 18, self.chemPlotDt )
-        print( "t3 = {}".format( time.time() - t0 ) )
         hsolve = moose.HSolve( self.elecid.path + '/hsolve' )
         hsolve.dt = elecDt
-        print( "t4 = {}".format( time.time() - t0 ) )
         hsolve.target = self.soma.path
-        print( "t5 = {}".format( time.time() - t0 ) )
         sys.stdout.flush()
     ################################################################
     ################################################################


### PR DESCRIPTION
1. An update/fix: now the ordering of chemical compartments is consistent with the ordering of electrical compartments.
2. Put in a feature so that when CompartmentBase geometry is changed, individual channels can indicate not to rescale their Gbar. This uses a child object named scaleFormula.
Neither of these changes should affect other sections of code, but possibly some of the tutorials and demos on rdesigneur may need checking. Also I'll need to go back and check the demos for my eLife 2017 paper.