### PR TITLE
Possible fixes to travis build failure on osx.

### DIFF
--- a/.travis/travis_build_osx.sh
+++ b/.travis/travis_build_osx.sh
@@ -21,10 +21,14 @@ set -o nounset                              # Treat unset variables as an error
 set -e
 
 (
-    mkdir -p _GSL_BUILD && cd _GSL_BUILD && cmake -DQUIET_MODE=ON -DDEBUG=ON -DPYTHON_EXECUTABLE=`which python` ..
+    mkdir -p _GSL_BUILD && cd _GSL_BUILD \
+        && cmake -DQUIET_MODE=ON -DDEBUG=ON \
+        -DPYTHON_EXECUTABLE=`which python` ..
     make && ctest --output-on-failure
     cd .. # Now with boost.
-    mkdir -p _BOOST_BUILD && cd _BOOST_BUILD && cmake -DWITH_BOOST=ON -DDEBUG=ON -DPYTHON_EXECUTABLE=`which python` ..
+    mkdir -p _BOOST_BUILD && cd _BOOST_BUILD \
+        && cmake -DWITH_BOOST=ON -DDEBUG=ON \
+        -DPYTHON_EXECUTABLE=`which python` ..
     make && ctest --output-on-failure
     cd ..
 )

--- a/.travis/travis_prepare_osx.sh
+++ b/.travis/travis_prepare_osx.sh
@@ -19,17 +19,19 @@
 
 set -o nounset                              # Treat unset variables as an error
 set +e
-rvm get head
-brew update
+#rvm get head
+#brew update
 #brew outdated cmake || brew install cmake
 brew install gsl
 brew install hdf5
+brew install python
+brew install numpy
 #brew outdated python || brew install python
 #brew outdated numpy || brew install homebrew/python/numpy
-#brew unlink numpy && brew link numpy || echo "Failed to link numpy"
+brew unlink numpy && brew link numpy || echo "Failed to link numpy"
 # Numpy caveats
 mkdir -p $HOME/Library/Python/2.7/lib/python/site-packages
 echo 'import sys; sys.path.insert(1, "/usr/local/lib/python2.7/site-packages")' >> $HOME/Library/Python/2.7/lib/python/site-packages/homebrew.pth
 # ensurepip
-python -m ensurepip
-pip install matplotlib
+#python -m ensurepip
+pip2 install matplotlib --user

--- a/.travis/travis_prepare_osx.sh
+++ b/.travis/travis_prepare_osx.sh
@@ -24,12 +24,12 @@ brew update
 #brew outdated cmake || brew install cmake
 brew install gsl
 brew install hdf5
-brew install homebrew/science/libsbml
 #brew outdated python || brew install python
 #brew outdated numpy || brew install homebrew/python/numpy
 #brew unlink numpy && brew link numpy || echo "Failed to link numpy"
 # Numpy caveats
 mkdir -p $HOME/Library/Python/2.7/lib/python/site-packages
 echo 'import sys; sys.path.insert(1, "/usr/local/lib/python2.7/site-packages")' >> $HOME/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+# ensurepip
+python -m ensurepip
 pip install matplotlib
-


### PR DESCRIPTION
Fixes to travis failure on osx due to missing `pip` command. 