### PR TITLE
Few clean up while reading and writing from/to SBML

### DIFF
--- a/python/moose/SBML/readSBML.py
+++ b/python/moose/SBML/readSBML.py
@@ -13,10 +13,12 @@
 **           copyright (C) 2003-2017 Upinder S. Bhalla. and NCBS
 Created : Thu May 13 10:19:00 2016(+0530)
 Version
-Last-Updated: Wed Oct 4 14:50:00 2017(+0530)
-
+Last-Updated: Sat Jan 6 1:21:00 2018(+0530)
           By:HarshaRani
 **********************************************************************/
+2018
+Jan6 :  - only if valid model exists, then printing the no of compartment,pool,reaction etc
+        - at reaction level a check made to see if path exist while creating a new reaction
 2017
 Oct 4 : - loadpath is cleaned up
 Sep 13: - After EnzymaticReaction's k2 is set, explicity ratio is set to 4 to make sure it balance.
@@ -106,33 +108,7 @@ def mooseReadSBML(filepath, loadpath, solver="ee"):
                 print("No model present.")
                 return moose.element('/')
             else:
-                print((" model: " + str(model)))
-                print(("functionDefinitions: " +
-                       str(model.getNumFunctionDefinitions())))
-                print(("    unitDefinitions: " +
-                       str(model.getNumUnitDefinitions())))
-                print(("   compartmentTypes: " +
-                       str(model.getNumCompartmentTypes())))
-                print(("        specieTypes: " +
-                       str(model.getNumSpeciesTypes())))
-                print(("       compartments: " +
-                       str(model.getNumCompartments())))
-                print(("            species: " +
-                       str(model.getNumSpecies())))
-                print(("         parameters: " +
-                       str(model.getNumParameters())))
-                print((" initialAssignments: " +
-                       str(model.getNumInitialAssignments())))
-                print(("              rules: " +
-                       str(model.getNumRules())))
-                print(("        constraints: " +
-                       str(model.getNumConstraints())))
-                print(("          reactions: " +
-                       str(model.getNumReactions())))
-                print(("             events: " +
-                       str(model.getNumEvents())))
-                print("\n")
-
+                
                 if (model.getNumCompartments() == 0):
                     return moose.element('/'), "Atleast one compartment is needed"
                 else:
@@ -185,6 +161,32 @@ def mooseReadSBML(filepath, loadpath, solver="ee"):
                         # as while reading in GUI the model will show up untill
                         # built which is not correct print "Deleted rest of the
                         # model"
+                        print((" model: " + str(model)))
+                        print(("functionDefinitions: " +
+                            str(model.getNumFunctionDefinitions())))
+                        print(("    unitDefinitions: " +
+                            str(model.getNumUnitDefinitions())))
+                        print(("   compartmentTypes: " +
+                               str(model.getNumCompartmentTypes())))
+                        print(("        specieTypes: " +
+                               str(model.getNumSpeciesTypes())))
+                        print(("       compartments: " +
+                               str(model.getNumCompartments())))
+                        print(("            species: " +
+                               str(model.getNumSpecies())))
+                        print(("         parameters: " +
+                               str(model.getNumParameters())))
+                        print((" initialAssignments: " +
+                               str(model.getNumInitialAssignments())))
+                        print(("              rules: " +
+                               str(model.getNumRules())))
+                        print(("        constraints: " +
+                               str(model.getNumConstraints())))
+                        print(("          reactions: " +
+                               str(model.getNumReactions())))
+                        print(("             events: " +
+                               str(model.getNumEvents())))
+                        print("\n")
                         moose.delete(basePath)
                         loadpath = moose.Shell('/')
             #return basePath, ""
@@ -639,11 +641,14 @@ def createReaction(model, specInfoMap, modelAnnotaInfo, globparameterIdValue,fun
                     sp = react.getSpecies()
                     sp = str(idBeginWith(sp))
                     speCompt = specInfoMap[sp]["comptId"].path
+
                     if group:
                         if moose.exists(speCompt+'/'+group):
                             speCompt = speCompt+'/'+group
                         else:
                             speCompt = (moose.Neutral(speCompt+'/'+group)).path
+                    if moose.exists(speCompt + '/' + rName):
+                        rName =rId
                     reaction_ = moose.Reac(speCompt + '/' + rName)
                     reactionCreated = True
                     reactSBMLIdMooseId[rName] = {
@@ -847,16 +852,13 @@ def unitsforRates(model):
 def getMembers(node, ruleMemlist):
     msg = ""
     found = True
-    if  node.getType() == libsbml.AST_LAMBDA:
-        #In lambda get Bvar values and getRighChild which will be kineticLaw
-        if node.getNumBvars() == 0:
-            print ("0")
-            return False
-
-        for i in range (0,node.getNumBvars()):
-            ruleMemlist.append(node.getChild(i).getName())
-        #funcD[funcName] = {"bvar" : bvar, "MathML":node.getRightChild()}
+    if node == None:
+        pass
+    elif node.getType() == libsbml.AST_POWER:
+        pass
+    
     elif node.getType() == libsbml.AST_FUNCTION:
+        #print " function"
         #funcName = node.getName()
         #funcValue = []
         #functionfound = False
@@ -868,8 +870,9 @@ def getMembers(node, ruleMemlist):
         #funcKL[node.getName()] = funcValue
 
     elif node.getType() == libsbml.AST_PLUS:
+        #print " plus ", node.getNumChildren()
         if node.getNumChildren() == 0:
-            print ("0")
+            #print ("0")
             return False
         getMembers(node.getChild(0), ruleMemlist)
         for i in range(1, node.getNumChildren()):
@@ -880,11 +883,10 @@ def getMembers(node, ruleMemlist):
         pass
     elif node.getType() == libsbml.AST_NAME:
         # This will be the ci term"
-
         ruleMemlist.append(node.getName())
     elif node.getType() == libsbml.AST_MINUS:
         if node.getNumChildren() == 0:
-            print("0")
+            #print("0")
             return False
         else:
             lchild = node.getLeftChild()
@@ -894,7 +896,7 @@ def getMembers(node, ruleMemlist):
     elif node.getType() == libsbml.AST_DIVIDE:
 
         if node.getNumChildren() == 0:
-            print("0")
+            #print("0")
             return False
         else:
             lchild = node.getLeftChild()
@@ -904,7 +906,7 @@ def getMembers(node, ruleMemlist):
 
     elif node.getType() == libsbml.AST_TIMES:
         if node.getNumChildren() == 0:
-            print ("0")
+            #print ("0")
             return False
         getMembers(node.getChild(0), ruleMemlist)
         for i in range(1, node.getNumChildren()):
@@ -912,13 +914,21 @@ def getMembers(node, ruleMemlist):
             getMembers(node.getChild(i), ruleMemlist)
 
     elif node.getType() == libsbml.AST_LAMBDA:
+        #In lambda get Bvar values and getRighChild which will be kineticLaw
         if node.getNumChildren() == 0:
-            print ("0")
+            #print ("0")
             return False
+        if node.getNumBvars() == 0:
+            #print ("0")
+            return False
+        '''
         getMembers(node.getChild(0), ruleMemlist)
         for i in range(1, node.getNumChildren()):
             getMembers(node.getChild(i), ruleMemlist)
-
+        '''
+        for i in range (0,node.getNumBvars()):
+            ruleMemlist.append(node.getChild(i).getName())
+        #funcD[funcName] = {"bvar" : bvar, "MathML":node.getRightChild()}
     elif node.getType() == libsbml.AST_FUNCTION_POWER:
         msg = msg + "\n moose is yet to handle \""+node.getName() + "\" operator"
         found = False

--- a/python/moose/SBML/writeSBML.py
+++ b/python/moose/SBML/writeSBML.py
@@ -13,11 +13,12 @@
 **           copyright (C) 2003-2017 Upinder S. Bhalla. and NCBS
 Created : Friday May 27 12:19:00 2016(+0530)
 Version
-Last-Updated: Sat 16 Dec 02:10:00 2017(+0530)
+Last-Updated: Sat 6 Jan 01:10:00 2018(+0530)
           By: HarshaRani
 **********************************************************************/
 /****************************
-
+2018
+Jan 6: for Product_formation_, k3 units depends on noofSub, prd was passed which is fixed
 2017
 Dec 15: If model path exists is checked
         Enz cplx is written only if enz,cplx,sub, prd exist, a clean check is made
@@ -402,7 +403,7 @@ def writeEnz(modelpath, cremodel_, sceneitems,groupInfo):
                         "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t" +
                         enzrate_law +
                         "\n \t </body>")
-                unit = parmUnit(noofPrd - 1, cremodel_)
+                unit = parmUnit(noofSub - 1, cremodel_)
                 printParameters(kl, "k3", k3, unit)
                 if groupName != moose.element('/'):
                     if groupName not in groupInfo:


### PR DESCRIPTION
Only if valid model exists, then printing the no of compartment,pool,reaction etc
at reaction level a check made to see if path exist while creating a new reaction if exist then id is taken

for Product_formation_, k3 units depends on noofSub , prd was passed which is fixed to sub.
S+E --> SE* (k1) sub
SE* --> S+E (k2) prd
SE* --> E+P (k3) sub
