### PR TITLE
Flag to prevent negative values in chemical computations

### DIFF
--- a/ksolve/Stoich.cpp
+++ b/ksolve/Stoich.cpp
@@ -75,6 +75,19 @@ const Cinfo* Stoich::initCinfo()
         &Stoich::getCompartment
     );
 
+    static ValueFinfo< Stoich, bool > allowNegative(
+        "allowNegative",
+        "Flag: allow negative values if true. Default is false."
+        " This is used to protect the chemical system from going unstable"
+        " in cases where the numerical integration gives a negative value."
+        " Typically it is a small negative value but is obviously"
+        " physically impossible. In some cases we want to use the " 
+        " solvers to handle general systems of equations (not purely "
+		" chemical ones), so we have this flag to allow it.",
+        &Stoich::setAllowNegative,
+        &Stoich::getAllowNegative
+    );
+
     static ReadOnlyValueFinfo< Stoich, unsigned int > numVarPools(
         "numVarPools",
         "Number of time-varying pools to be computed by the "
@@ -258,7 +271,8 @@ static const Cinfo* stoichCinfo = Stoich::initCinfo();
 
 Stoich::Stoich()
     :
-    useOneWay_( 0 ),
+    useOneWay_( false ),
+    allowNegative_( false ),
     path_( "" ),
     ksolve_(), // Must be reassigned to build stoich system.
     dsolve_(), // Must be assigned if diffusion is planned.
@@ -308,6 +322,16 @@ void Stoich::setOneWay( bool v )
 bool Stoich::getOneWay() const
 {
     return useOneWay_;
+}
+
+void Stoich::setAllowNegative( bool v )
+{
+    allowNegative_ = v;
+}
+
+bool Stoich::getAllowNegative() const
+{
+    return allowNegative_;
 }
 
 void Stoich::setPath( const Eref& e, string v )
@@ -634,7 +658,7 @@ const FuncTerm* Stoich::funcs( unsigned int i ) const
 bool Stoich::isFuncTarget( unsigned int poolIndex ) const
 {
 	assert( poolIndex < funcTarget_.size() );
-	return ( funcTarget_[poolIndex] != ~0 );
+	return ( funcTarget_[poolIndex] != ~0U );
 }
 
 vector< int > Stoich::getMatrixEntry() const

--- a/ksolve/Stoich.h
+++ b/ksolve/Stoich.h
@@ -59,6 +59,10 @@ class Stoich
 		void setOneWay( bool v );
 		bool getOneWay() const;
 
+		// Flag that defines permission for pool values to go negative.
+		void setAllowNegative( bool v );
+		bool getAllowNegative() const;
+
 		/// Returns number of local pools that are updated by solver
 		unsigned int getNumVarPools() const;
 
@@ -510,6 +514,15 @@ class Stoich
 		 * reactions, as is needed in the case of the Gillespie algorithm.
 		 */
 		bool useOneWay_;
+
+		/** 
+		 * True if pools are permitted to take negative concentrations.
+		 * This may happen if solver is handling a general equation system
+		 * that is not constrained by chemical rules.
+		 * Defaults to False, so that we cannot have negative concs.
+		 */
+		bool allowNegative_;
+
 		string path_;
 
 		/// This contains the Id of the Kinetic solver.

--- a/ksolve/VoxelPools.cpp
+++ b/ksolve/VoxelPools.cpp
@@ -215,6 +215,13 @@ void VoxelPools::advance( const ProcInfo* p )
                 , p->dt
                 );
 #endif
+    if ( !stoichPtr_->getAllowNegative() ) { // clean out negatives
+		unsigned int nv = stoichPtr_->getNumVarPools();
+		double* vs = varS();
+		for ( unsigned int i = 0; i < nv; ++i ) {
+			*vs++ = (1.0 - signbit( *vs) ) * *vs; // Zero out all negatives.
+		}
+	}
 }
 
 void VoxelPools::setInitDt( double dt )

--- a/ksolve/VoxelPools.cpp
+++ b/ksolve/VoxelPools.cpp
@@ -219,7 +219,8 @@ void VoxelPools::advance( const ProcInfo* p )
 		unsigned int nv = stoichPtr_->getNumVarPools();
 		double* vs = varS();
 		for ( unsigned int i = 0; i < nv; ++i ) {
-			*vs++ = (1.0 - signbit( *vs) ) * *vs; // Zero out all negatives.
+			if ( signbit(*vs) )
+				vs[i] = 0.0;
 		}
 	}
 }


### PR DESCRIPTION
These commits add a flag to the Stoich object, Stoich::allowNegative,  to allow or prevent negative values for coming up during chemical computations. Default is True, so that negative values are prevented.