### PR TITLE
New rmoogli and moogul for 3-D morphology display

### DIFF
--- a/python/rdesigneur/moogul.py
+++ b/python/rdesigneur/moogul.py
@@ -59,7 +59,8 @@ class MooView:
         self.ax.set_ylim3d( self.coordMin, self.coordMax )
         self.ax.set_zlim3d( self.coordMin, self.coordMax )
         #self.ax.view_init( elev = -80.0, azim = 90.0 )
-        self.colorbar = plt.colorbar( self.drawables_[0].segments )
+        #self.colorbar = plt.colorbar( self.drawables_[0].segments )
+        self.colorbar = self.fig_.colorbar( self.drawables_[0].segments )
         self.colorbar.set_label( self.drawables_[0].fieldInfo[3])
         self.timeStr = self.ax.text2D( 0.05, 0.05, 
                 "Time= 0.0", transform=self.ax.transAxes)
@@ -71,7 +72,7 @@ class MooView:
         self.timeStr.set_text( "Time= " + str(time) )
         for i in self.drawables_:
             i.updateValues()
-        self.fig_.canvas.draw()
+        #self.fig_.canvas.draw()
         plt.pause(0.001)
 
     def moveView(self, event):

--- a/python/rdesigneur/moogul.py
+++ b/python/rdesigneur/moogul.py
@@ -1,0 +1,267 @@
+# Moogul.py: MOOSE Graphics Using Lines
+# This is a fallback graphics interface for displaying neurons using
+# regular matplotlib routines.
+# Put in because the GL versions like moogli need all sorts of difficult 
+# libraries and dependencies.
+# Copyright (C) Upinder S. Bhalla NCBS 2018
+# This program is licensed under the GNU Public License version 3.
+#
+
+import moose
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d.art3d import Line3DCollection
+
+class MoogulError( Exception ):
+    def __init__( self, value ):
+        self.value = value
+    def __str__( self ):
+        return repr( self.value )
+
+class MooView:
+    ''' The MooView class is a window in which to display one or more 
+    moose cells, using the MooCell class.'''
+    def __init__( self, swx = 10, swy = 12, hideAxis = True
+    ):
+        plt.ion()
+        self.fig_ = plt.figure( figsize = (swx, swy) )
+        self.ax = self.fig_.add_subplot(111, projection='3d' )
+        self.drawables_ = []
+        self.fig_.canvas.mpl_connect("key_press_event", self.moveView )
+        plt.rcParams['keymap.xscale'] = ''
+        plt.rcParams['keymap.yscale'] = ''
+        plt.rcParams['keymap.zoom'] = ''
+        plt.rcParams['keymap.back'] = ''
+        plt.rcParams['keymap.home'] = ''
+        plt.rcParams['keymap.forward'] = ''
+        plt.rcParams['keymap.all_axes'] = ''
+        if hideAxis:
+            self.ax.set_axis_off()
+        self.ax.margins( tight = True )
+        self.sensitivity = 7.0 # degrees rotation
+        self.zoom = 1.05
+
+    def addDrawable( self, n ):
+        self.drawables_.append( n )
+
+    def firstDraw( self ):
+        self.coordMax = 0.0 
+        self.coordMin = 0.0
+        for i in self.drawables_:
+            cmax, cmin = i.drawForTheFirstTime( self.ax )
+            self.coordMax = max( cmax, self.coordMax )
+            self.coordMin = min( cmin, self.coordMin )
+        if self.coordMin == self.coordMax:
+            self.coordMax = 1+self.coordMin
+
+            
+        self.ax.set_xlim3d( self.coordMin, self.coordMax )
+        self.ax.set_ylim3d( self.coordMin, self.coordMax )
+        self.ax.set_zlim3d( self.coordMin, self.coordMax )
+        #self.ax.view_init( elev = -80.0, azim = 90.0 )
+        self.colorbar = plt.colorbar( self.drawables_[0].segments )
+        self.colorbar.set_label( self.drawables_[0].fieldInfo[3])
+        self.timeStr = self.ax.text2D( 0.05, 0.05, 
+                "Time= 0.0", transform=self.ax.transAxes)
+        self.fig_.canvas.draw()
+        plt.show()
+
+    def updateValues( self ):
+        time = moose.element( '/clock' ).currentTime
+        self.timeStr.set_text( "Time= " + str(time) )
+        for i in self.drawables_:
+            i.updateValues()
+        self.fig_.canvas.draw()
+        plt.pause(0.001)
+
+    def moveView(self, event):
+        x0 = self.ax.get_xbound()[0]
+        x1 = self.ax.get_xbound()[1]
+        xk = (x0 - x1) / self.sensitivity
+        y0 = self.ax.get_ybound()[0]
+        y1 = self.ax.get_ybound()[1]
+        yk = (y0 - y1) / self.sensitivity
+        z0 = self.ax.get_zbound()[0]
+        z1 = self.ax.get_zbound()[1]
+        zk = (z0 - z1) / self.sensitivity
+        #print self.ax.azim, self.ax.elev, self.ax.dist
+
+        if event.key == "up" or event.key == "k":
+            self.ax.set_ybound( y0 + yk, y1 + yk )
+        if event.key == "down" or event.key == "j":
+            self.ax.set_ybound( y0 - yk, y1 - yk )
+        if event.key == "left" or event.key == "h":
+            self.ax.set_xbound( x0 + xk, x1 + xk )
+        if event.key == "right" or event.key == "l":
+            self.ax.set_xbound( x0 - xk, x1 - xk )
+        if event.key == "ctrl+up":
+            self.ax.set_zbound( z0 + zk, z1 + zk )
+        if event.key == "ctrl+down":
+            self.ax.set_zbound( z0 - zk, z1 - zk )
+        if event.key == "." or event.key == ">":
+            self.ax.set_xbound( x0/self.zoom, x1/self.zoom )
+            self.ax.set_ybound( y0/self.zoom, y1/self.zoom )
+            self.ax.set_zbound( z0/self.zoom, z1/self.zoom )
+        if event.key == "," or event.key == "<":
+            self.ax.set_xbound( x0*self.zoom, x1*self.zoom )
+            self.ax.set_ybound( y0*self.zoom, y1*self.zoom )
+            self.ax.set_zbound( z0*self.zoom, z1*self.zoom )
+        if event.key == "a":
+            self.ax.set_xlim3d( self.coordMin, self.coordMax )
+            self.ax.set_ylim3d( self.coordMin, self.coordMax )
+            self.ax.set_zlim3d( self.coordMin, self.coordMax )
+        if event.key == "p":
+            self.ax.elev += self.sensitivity
+        if event.key == "P":
+            self.ax.elev -= self.sensitivity
+        if event.key == "y":
+            self.ax.azim += self.sensitivity
+        if event.key == "Y":
+            self.ax.azim -= self.sensitivity
+        self.fig_.canvas.draw()
+
+#####################################################################
+
+class MooDrawable:
+    ''' Base class for drawing things'''
+    def __init__( self,
+        fieldInfo, field, relativeObj, maxLineWidth,
+        colormap,
+        lenScale, diaScale, autoscale,
+        valMin, valMax
+    ):
+        self.field = field
+        self.relativeObj = relativeObj
+        self.maxLineWidth = maxLineWidth
+        self.lenScale = lenScale
+        self.diaScale = diaScale
+        self.colormap = colormap
+        self.autoscale = autoscale
+        self.valMin = valMin
+        self.valMax = valMax
+        self.fieldInfo = fieldInfo
+        self.fieldScale = fieldInfo[2]
+        #FieldInfo = [baseclass, fieldGetFunc, scale, axisText, min, max]
+
+    def updateValues( self ):
+        ''' Obtains values from the associated cell'''
+        self.val = np.array([moose.getField( i, self.field, 'double' ) for i in self.activeObjs]) * self.fieldScale
+        cmap = plt.get_cmap( self.colormap )
+        if self.autoscale:
+            valMin = min( self.val )
+            valMax = max( self.val )
+        else:
+            valMin = self.valMin
+            valMax = self.valMax
+        scaleVal = (self.val - valMin) / (valMax - valMin)
+        self.rgba = [ cmap(i) for i in scaleVal ]
+        self.segments.set_color( self.rgba )
+        return
+
+    def drawForTheFirstTime( self, ax ):
+        self.segments = Line3DCollection( self.activeCoords, 
+                linewidths = self.linewidth, cmap = plt.get_cmap(self.colormap) )
+        self.cax = ax.add_collection3d( self.segments )
+        self.segments.set_array( self.valMin + np.array( range( len(self.activeCoords) ) ) * (self.valMax-self.valMin)/len(self.activeCoords) )
+        return self.coordMax, self.coordMin
+
+
+
+
+#####################################################################
+
+class MooNeuron( MooDrawable ):
+    ''' Draws collection of line segments of defined dia and color'''
+    def __init__( self,
+        neuronId,
+        fieldInfo,
+        field = 'Vm', 
+        relativeObj = '.', 
+        maxLineWidth = 20, 
+        colormap = 'jet', 
+        lenScale = 1e6, diaScale = 1e6, autoscale = False, 
+        valMin = -0.1, valMax = 0.05,
+    ):
+        #self.isFieldOnCompt = 
+            #field in ( 'Vm', 'Im', 'Rm', 'Cm', 'Ra', 'inject', 'diameter' )
+        
+        MooDrawable.__init__( self, fieldInfo, field = field, 
+                relativeObj = relativeObj, maxLineWidth = maxLineWidth, 
+                colormap = colormap, lenScale = lenScale, 
+                diaScale = diaScale, autoscale = autoscale, 
+                valMin = valMin, valMax = valMax )
+        self.neuronId = neuronId
+        self.updateCoords()
+
+    def updateCoords( self ):
+        ''' Obtains coords from the associated cell'''
+        self.compts_ = self.neuronId.compartments
+        #coords = np.array([[[i.x0,i.y0,i.z0],[i.x,i.y,i.z]] 
+            #for i in self.compts_])
+        coords = np.array([[[i.z0,i.x0,i.y0],[i.z,i.x,i.y]] 
+            for i in self.compts_])
+        dia = np.array([i.diameter for i in self.compts_])
+        if self.relativeObj == '.':
+            self.activeCoords = coords
+            self.activeDia = dia
+            self.activeObjs = self.compts_
+        else:
+            self.activeObjs = []
+            self.activeCoords = []
+            self.activeDia = []
+            for i,j,k in zip( self.compts_, coords, dia ):
+                #print i.path, self.relativeObj
+                if moose.exists( i.path + '/' + self.relativeObj ):
+                    elm = moose.element( i.path + '/' + self.relativeObj )
+                    self.activeObjs.append( elm )
+                    self.activeCoords.append( j )
+                    self.activeDia.append( k )
+
+        self.activeCoords = np.array( self.activeCoords ) * self.lenScale
+        self.coordMax = np.amax( self.activeCoords )
+        self.coordMin = np.amin( self.activeCoords )
+        self.linewidth = np.array( [ min(self.maxLineWidth, 1 + int(i * self.diaScale )) for i in self.activeDia ] )
+
+        return
+
+#####################################################################
+class MooReacSystem( MooDrawable ):
+    ''' Draws collection of line segments of defined dia and color'''
+    def __init__( self,
+        mooObj, fieldInfo,
+        field = 'conc', 
+        relativeObj = '.', 
+        maxLineWidth = 100, 
+        colormap = 'jet', 
+        lenScale = 1e6, diaScale = 20e6, autoscale = False, 
+        valMin = 0.0, valMax = 1.0
+    ):
+        
+        MooDrawable.__init__( self, fieldInfo, field = field, 
+                relativeObj = relativeObj, maxLineWidth = maxLineWidth, 
+                colormap = colormap, lenScale = lenScale, 
+                diaScale = diaScale, autoscale = autoscale, 
+                valMin = valMin, valMax = valMax )
+        self.mooObj = mooObj
+        self.updateCoords()
+
+    def updateCoords( self ):
+        ''' For now a dummy cylinder '''
+        dx = 1e-6
+        dummyDia = 20e-6
+        numObj = len( self.mooObj )
+        x = np.arange( 0, (numObj+1) * dx, dx )
+        y = np.zeros( numObj + 1)
+        z = np.zeros( numObj + 1)
+
+        coords = np.array([[[i*dx,0,0],[(i+1)*dx,0,0]] for i in range( numObj )] )
+        dia = np.ones( numObj ) * dummyDia
+        self.activeCoords = coords
+        self.activeDia = dia
+        self.activeObjs = self.mooObj
+        self.activeCoords = np.array( self.activeCoords ) * self.lenScale
+        self.coordMax = np.amax( self.activeCoords )
+        self.coordMin = np.amin( self.activeCoords )
+        self.linewidth = np.array( [ min(self.maxLineWidth, 1 + int(i * self.diaScale )) for i in self.activeDia ] )
+
+        return

--- a/python/rdesigneur/moogul.py
+++ b/python/rdesigneur/moogul.py
@@ -37,7 +37,8 @@ class MooView:
         plt.rcParams['keymap.all_axes'] = ''
         if hideAxis:
             self.ax.set_axis_off()
-        self.ax.margins( tight = True )
+        #self.ax.margins( tight = True )
+        self.ax.margins()
         self.sensitivity = 7.0 # degrees rotation
         self.zoom = 1.05
 

--- a/python/rdesigneur/rdesigneur.py
+++ b/python/rdesigneur/rdesigneur.py
@@ -27,9 +27,12 @@ import itertools
 import sys
 import time
 
-import rdesigneur.rmoogli as rmoogli
+#import rdesigneur.rmoogli as rmoogli
+#from . import fixXreacs
+#from rdesigneur.rdesigneurProtos import *
+import rmoogli
 import fixXreacs
-from rdesigneur.rdesigneurProtos import *
+from rdesigneurProtos import *
 
 from moose.neuroml.NeuroML import NeuroML
 from moose.neuroml.ChannelML import ChannelML
@@ -645,13 +648,25 @@ class rdesigneur:
     ################################################################
     # Here we display the plots and moogli
     ################################################################
+
     def displayMoogli( self, moogliDt, runtime, rotation = math.pi/500.0, fullscreen = False):
         rmoogli.displayMoogli( self, moogliDt, runtime, rotation, fullscreen )
+        pr = moose.PyRun( '/model/updateMoogli' )
 
-    def display( self ):
+        pr.runString = '''
+import rmoogli
+rmoogli.updateMoogliViewer()
+'''
+        moose.setClock( pr.tick, moogliDt )
+        moose.reinit()
+        moose.start( runtime )
+        self.display( len( self.moogNames ) + 1 )
+
+    def display( self, startIndex = 0 ):
         import matplotlib.pyplot as plt
         for i in self.plotNames:
-            plt.figure( i[2] )
+            print( "###############" + str( i[2] + startIndex ) )
+            plt.figure( i[2] + startIndex )
             plt.title( i[1] )
             plt.xlabel( "Time (s)" )
             plt.ylabel( i[4] )

--- a/python/rdesigneur/rdesigneur.py
+++ b/python/rdesigneur/rdesigneur.py
@@ -27,12 +27,13 @@ import itertools
 import sys
 import time
 
-#import rdesigneur.rmoogli as rmoogli
-#from . import fixXreacs
-#from rdesigneur.rdesigneurProtos import *
-import rmoogli
+import rdesigneur.rmoogli as rmoogli
+from rdesigneur.rdesigneurProtos import *
 import fixXreacs
-from rdesigneurProtos import *
+#from . import fixXreacs
+#from rdesigneur.rmoogli import *
+#import rmoogli
+#from rdesigneurProtos import *
 
 from moose.neuroml.NeuroML import NeuroML
 from moose.neuroml.ChannelML import ChannelML
@@ -654,8 +655,8 @@ class rdesigneur:
         pr = moose.PyRun( '/model/updateMoogli' )
 
         pr.runString = '''
-import rmoogli
-rmoogli.updateMoogliViewer()
+import rdesigneur.rmoogli
+rdesigneur.rmoogli.updateMoogliViewer()
 '''
         moose.setClock( pr.tick, moogliDt )
         moose.reinit()

--- a/python/rdesigneur/rdesigneur.py
+++ b/python/rdesigneur/rdesigneur.py
@@ -665,7 +665,6 @@ rmoogli.updateMoogliViewer()
     def display( self, startIndex = 0 ):
         import matplotlib.pyplot as plt
         for i in self.plotNames:
-            print( "###############" + str( i[2] + startIndex ) )
             plt.figure( i[2] + startIndex )
             plt.title( i[1] )
             plt.xlabel( "Time (s)" )

--- a/python/rdesigneur/rmoogli.py
+++ b/python/rdesigneur/rmoogli.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, print_function
 # Copyright (C) Upinder S. Bhalla NCBS 2018
 # This program is licensed under the GNU Public License version 3.
 
-import rdesigneur.moogul
+import rdesigneur.moogul as moogul
 mooViews = []
 
 def makeMoogli( rd, mooObj, args, fieldInfo ):

--- a/python/rdesigneur/rmoogli.py
+++ b/python/rdesigneur/rmoogli.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 # rmoogli.py: rdesigneur Moogli interface
 # This is a fallback version designed to work with moogul but using almost
 # the same interface as far as rdesigneur is concerned.
@@ -5,8 +6,8 @@
 # libraries and dependencies.
 # Copyright (C) Upinder S. Bhalla NCBS 2018
 # This program is licensed under the GNU Public License version 3.
-#
-import moogul
+
+import rdesigneur.moogul
 mooViews = []
 
 def makeMoogli( rd, mooObj, args, fieldInfo ):

--- a/python/rdesigneur/rmoogli.py
+++ b/python/rdesigneur/rmoogli.py
@@ -1,178 +1,51 @@
-# -*- coding: utf-8 -*-
-#########################################################################
-## rdesigneur0_4.py ---
-## This program is part of 'MOOSE', the
-## Messaging Object Oriented Simulation Environment.
-##           Copyright (C) 2014 Upinder S. Bhalla. and NCBS
-## It is made available under the terms of the
-## GNU General Public License version 2 or later.
-## See the file COPYING.LIB for the full notice.
-#########################################################################
+# rmoogli.py: rdesigneur Moogli interface
+# This is a fallback version designed to work with moogul but using almost
+# the same interface as far as rdesigneur is concerned.
+# Put in because the GL versions like moogli need all sorts of difficult 
+# libraries and dependencies.
+# Copyright (C) Upinder S. Bhalla NCBS 2018
+# This program is licensed under the GNU Public License version 3.
+#
+import moogul
+mooViews = []
 
-import math
-import sys
-import moose
-import os
-
-# Check if DISPLAY environment variable is properly set. If not, warn the user
-# and continue.
-hasDisplay = True
-display = os.environ.get('DISPLAY',  '' )
-if not display:
-    hasDisplay = False
-    print( "Warning: Environment variable DISPLAY is not set."
-            " Did you forget to pass -X or -Y switch to ssh command?\n"
-            "Anyway, MOOSE will continue without graphics.\n"
-            )
-
-hasMoogli = True
-
-if hasDisplay:
-    try:
-        import matplotlib
-        from PyQt4 import QtGui
-        import moogli
-        import moogli.extensions.moose
-        app = QtGui.QApplication(sys.argv)
-    except Exception as e:
-        print( 'Warning: Moogli not found. All moogli calls will use dummy functions' )
-        hasMoogli = False
-
-
-runtime = 0.0
-moogliDt = 1.0
-rotation = math.pi / 500.0
-
-def getComptParent( obj ):
-    k = moose.element(obj)
-    while not k.isA[ "CompartmentBase" ]:
-        if k == moose.element( '/' ):
-            return k.path
-        k = moose.element( k.parent )
-    return k.path
-
-#######################################################################
-## Here we set up the callback functions for the viewer
-def prelude( view ):
-    view.home()
-    view.pitch( math.pi / 2.0 )
-    view.zoom( 0.05 )
-    #network.groups["soma"].set( "color", moogli.colors.RED )
-
-# This func is used for the first viewer, it has to handle advancing time.
-def interlude( view ):
-    moose.start( moogliDt )
-    val = [ moose.getField( i, view.mooField, "double" ) * view.mooScale for i in view.mooObj ]
-    view.mooGroup.set("color", val, view.mapper)
-    view.yaw( rotation )
-    #print moogliDt, len( val ), runtime
-    if moose.element("/clock").currentTime >= runtime:
-        view.stop()
-
-# This func is used for later viewers, that don't handle advancing time.
-def interlude2( view ):
-    val = [ moose.getField( i, view.mooField, "double" ) * view.mooScale for i in view.mooObj ]
-
-    view.mooGroup.set("color", val, view.mapper)
-    view.yaw( rotation )
-    if moose.element("/clock").currentTime >= runtime:
-        view.stop()
-
-def postlude( view ):
-    view.rd.display()
-
-def makeMoogli( rd, mooObj, moogliEntry, fieldInfo ):
-    if not hasMoogli:
-        return None
-    mooField = moogliEntry[3]
+def makeMoogli( rd, mooObj, args, fieldInfo ):
+    #mooObj is currently poorly handled. Ideally it should simply be a 
+    # vector of objects to plot, each with coords. This could be readily
+    # used to build up the display in a neutral manner.
+    # Another version is to have a vector of objects to plot, only as a 
+    # way to get at their fields. We would separately need mapping to
+    # neuron compartments and index along length.
+    # Cleaner still would be to have the C code give a vector of values
+    # For now it means something different for chem and elec displays.
+    #moogliEntry = [elecPath,bool,whichObjToDisplay,FieldToDisplay,titleForDisplay,rangeMin,rangeMax]
+    mooField = args[3]
+    relObjPath = args[2]
     numMoogli = len( mooObj )
-    network = moogli.extensions.moose.read( path = rd.elecid.path, vertices=15)
-    #print len( network.groups["spine"].shapes )
-    #print len( network.groups["dendrite"].shapes )
-    #print len( network.groups["soma"].shapes )
-    #soma = network.groups["soma"].shapes[ '/model/elec/soma']
-    #print network.groups["soma"].shapes
 
-    soma = network.groups["soma"].shapes[ rd.elecid.path + '/soma[0]']
-    if ( mooField == 'n' or mooField == 'conc' ):
-        updateGroup = soma.subdivide( numMoogli )
-        displayObj = mooObj
+    viewer = moogul.MooView()
+    if mooField == 'n' or mooField == 'conc':
+        #moogul.updateDiffCoords( mooObj )
+        reacSystem = moogul.MooReacSystem( mooObj, fieldInfo, 
+                field = mooField, relativeObj = relObjPath, 
+                valMin = args[5], valMax = args[6] )
+        viewer.addDrawable( reacSystem )
     else:
-        shell = moose.element( '/' )
-        displayObj = [i for i in mooObj if i != shell ]
-        cpa = [getComptParent( i ) for i in displayObj ]
-        updateGroup = moogli.Group( "update" )
-        updateShapes = [network.shapes[i] for i in cpa]
-        #print "########### Len( cpa, mooObj ) = ", len( cpa ), len( mooObj ), len( updateShapes )
-        updateGroup.attach_shapes( updateShapes )
+        neuron = moogul.MooNeuron( rd.elecid, fieldInfo,
+                field = mooField, relativeObj = relObjPath,
+                valMin = args[5], valMax = args[6] )
+        viewer.addDrawable( neuron )
 
-    normalizer = moogli.utilities.normalizer(
-                    moogliEntry[5], moogliEntry[6],
-                    clipleft =True,
-                    clipright = True )
-    colormap = moogli.colors.MatplotlibColorMap(matplotlib.cm.rainbow)
-    mapper = moogli.utilities.mapper(colormap, normalizer)
-
-
-    viewer = moogli.Viewer("Viewer")
-    viewer.setWindowTitle( moogliEntry[4] )
-    if ( mooField == 'n' or mooField == 'conc' ):
-        viewer.attach_shapes( updateGroup.shapes.values())
-        viewer.detach_shape(soma)
-    else:
-        viewer.attach_shapes(network.shapes.values())
-
-    if len( rd.moogNames ) == 0:
-        view = moogli.View("main-view",
-                       prelude=prelude,
-                       interlude=interlude,
-                       postlude = postlude)
-    else:
-        view = moogli.View("main-view",
-                       prelude=prelude,
-                       interlude=interlude2)
-
-    cb = moogli.widgets.ColorBar(id="cb",
-                                 title=fieldInfo[3],
-                                 text_color=moogli.colors.BLACK,
-                                 position=moogli.geometry.Vec3f(0.975, 0.5, 0.0),
-                                 size=moogli.geometry.Vec3f(0.30, 0.05, 0.0),
-                                 text_font="/usr/share/fonts/truetype/ubuntu-font-family/Ubuntu-R.ttf",
-                                 orientation=math.pi / 2.0,
-                                 text_character_size=16,
-                                 label_formatting_precision=0,
-                                 colormap=moogli.colors.MatplotlibColorMap(matplotlib.cm.rainbow),
-                                 color_resolution=100,
-                                 scalar_range=moogli.geometry.Vec2f(
-                                     moogliEntry[5],
-                                     moogliEntry[6]))
-    cb.set_num_labels(3)
-    view.attach_color_bar(cb)
-    view.rd = rd
-    view.mooObj = displayObj
-    view.mooGroup = updateGroup
-    view.mooField = mooField
-    view.mooScale = fieldInfo[2]
-    view.mapper = mapper
-    viewer.attach_view(view)
     return viewer
 
+def updateMoogliViewer():
+    for i in mooViews:
+        i.updateValues()
+    
+
 def displayMoogli( rd, _dt, _runtime, _rotation, fullscreen = False ):
-    if not hasMoogli:
-        return None
-    global runtime
-    global moogliDt
-    global rotation
-    runtime = _runtime
-    moogliDt = _dt
-    rotation = _rotation
+    global mooViews
+    mooViews = rd.moogNames
     for i in rd.moogNames:
-        if fullscreen:
-            i.showMaximized()
-        else:
-            i.show()
-        i.start()
-    #viewer.showMaximized()
-    #viewer.show()
-    #viewer.start()
-    return app.exec_()
+        i.firstDraw()
+


### PR DESCRIPTION
This introduces a pure matplotlib-based 3D display for neurons as an almost-plugin replacement for moogli. It is slower and less beautiful than moogli, but it is just matplotlib and hence much easier to configure and maintain.
Please check that the tutorials/Rdesigneur examples run with this. They do on my machine.