### PR TITLE
Update moose.py

### DIFF
--- a/python/moose/moose.py
+++ b/python/moose/moose.py
@@ -209,6 +209,7 @@ def mooseAddChemSolver(modelpath, solver):
               "Runge Kutta"       ("gsl")
 
     """
+    global chemError_
     if chemImport_:
         chemError_ = _chemUtil.add_Delete_ChemicalSolver.mooseAddChemSolver(modelpath, solver)
         return chemError_


### PR DESCRIPTION
This caused few scripts to fail on  moose-examples. `chemError_` could not be printed because it was not in scope.