### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status - master](https://travis-ci.org/BhallaLab/moose-core.svg?branch=master)](https://travis-ci.org/BhallaLab/moose-core) | [![PyPI version](https://badge.fury.io/py/pymoose.svg)](https://badge.fury.io/py/pymoose)
+[![Build Status - master](https://travis-ci.org/BhallaLab/moose-core.svg?branch=master)](https://travis-ci.org/BhallaLab/moose-core) | [![PyPI version](https://badge.fury.io/py/pymoose.svg)](https://badge.fury.io/py/pymoose) | [Nightly Linux Build on OBS](https://software.opensuse.org//download.html?project=home%3Amoose&package=pymoose)
 
 This is the core computational engine of [MOOSE simulator](https://github.com/BhallaLab/moose). This repository contains
 C++ codebase and python interface called `pymoose`. For more details about MOOSE simulator, visit https://moose.ncbs.res.in .


### PR DESCRIPTION
Added URL to nightly build of moose-core on OBS. This package is used to test `moose-examples` on travis. This should be the source of bleeding-edge moose package. 

No badge support till https://github.com/openSUSE/open-build-service/issues/2908 is implemented.