### PR TITLE
HotFix: Update setup.cmake.py

### DIFF
--- a/python/setup.cmake.py
+++ b/python/setup.cmake.py
@@ -57,7 +57,7 @@ setup(
                                     , 'moose.neuroml', 'moose.neuroml2'
                                     , 'moose.chemUtil', 'moose.chemMerge'
                                 ],
-        install_requires       = [ 'matplotlib', 'numpy' ],
+        install_requires       = [ 'numpy' ],
         package_dir            = { 'moose' : 'moose', 'rdesigneur' : 'rdesigneur' },
         package_data           = { 'moose' : ['_moose' + suffix, 'neuroml2/schema/NeuroMLCoreDimensions.xml'] },
         )


### PR DESCRIPTION
Install should not require matplotlib. Use can install it later.