### PR TITLE
Hotfix: Fixes to build failure on OSX because cmake does not set MACOSX to 1 anymore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,9 +352,18 @@ if(SYSTEM_SHARED_LIBS)
     list(REMOVE_DUPLICATES SYSTEM_SHARED_LIBS)
 endif( )
 
+# cmake --help-policy CMP0042. Also in pymoose/CMakeLists.txt 
+# More details:
+# https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
+# especially section 'Mac OS X and the RPATH'
+# Switching is OFF since all libraries are statically linked in module.
+if(APPLE)
+    set_target_properties( libmoose PROPERTIES MACOSX_RPATH OFF)
+endif(APPLE)
+
 # MAC linker does not understand many of gnu-ld options.
 # message( DEBUG "Shared libs: ${SYSTEM_SHARED_LIBS}")
-if(MACOSX)
+if(APPLE)
     target_link_libraries(libmoose
         "-Wl,-all_load"
         ${MOOSE_LIBRARIES}
@@ -365,7 +374,7 @@ if(MACOSX)
         ${SYSTEM_SHARED_LIBS}
         ${CMAKE_DL_LIBS}
         )
-ELSE(MACOSX)
+else(APPLE)
     target_link_libraries(libmoose
         "-Wl,--whole-archive"
         ${MOOSE_LIBRARIES}
@@ -373,7 +382,7 @@ ELSE(MACOSX)
         "-Wl,--no-whole-archive"
         ${SYSTEM_SHARED_LIBS}
         )
-endif(MACOSX)
+endif(APPLE)
 
 add_dependencies(moose.bin libmoose)
 target_link_libraries(moose.bin moose ${CMAKE_DL_LIBS})

--- a/pymoose/CMakeLists.txt
+++ b/pymoose/CMakeLists.txt
@@ -77,22 +77,22 @@ set_target_properties(_moose PROPERTIES
     SUFFIX ${PYTHON_SO_EXTENSION}
     )
 
-# On OSX+Brew and python2.5; link with libstdc++
-if(MACOSX AND ("${PYTHON_VERSION_MAJOR}" STREQUAL "2"))
-    add_definitions( -std=c++11 -stdlib=libc++ )
-endif()
-
 # see issue #80
 if(HDF5_FOUND AND WITH_NSDF)
     set_target_properties( _moose PROPERTIES LINK_FLAGS "-L${HDF5_LIBRARY_DIRS}" )
 endif()
 
-if(MACOSX)
+if(APPLE)
     set(CMAKE_MODULE_LINKER_FLAGS "-undefined dynamic_lookup")
     message(STATUS "ADDING some linker flags ${CMAKE_EXE_LINKER_FLAGS}")
-endif(MACOSX)
+endif(APPLE)
 
-if(MACOSX)
+# cmake --help-policy CMP0042
+if(APPLE)
+    set_target_properties( _moose PROPERTIES MACOSX_RPATH OFF)
+endif(APPLE)
+
+if(APPLE)
     target_link_libraries( _moose
         "-Wl,-all_load"
         ${MOOSE_LIBRARIES}
@@ -101,7 +101,7 @@ if(MACOSX)
     target_link_libraries(_moose
         ${SYSTEM_SHARED_LIBS}
         )
-else(MACOSX)
+else(APPLE)
     target_link_libraries(_moose
         "-Wl,--whole-archive"
         ${MOOSE_LIBRARIES}
@@ -109,7 +109,7 @@ else(MACOSX)
         "-Wl,--no-whole-archive"
         ${SYSTEM_SHARED_LIBS}
         )
-endif(MACOSX)
+endif(APPLE)
 add_custom_command(TARGET _moose POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan
         "MOOSE python extention is successfully built. Now "


### PR DESCRIPTION
Changed 'MACOSX' boolean to 'APPLE' . Seems like cmake has deprecated it. Also set the newly introduced policy CMP0045 to FALSE. See the CMakeLists.txt for details and links to wiki page for explanation. 