### PR TITLE
Fixes to Hsolve and Neuron

### DIFF
--- a/biophysics/Neuron.cpp
+++ b/biophysics/Neuron.cpp
@@ -1141,10 +1141,29 @@ void Neuron::setChannelDistribution( const Eref& e, vector< string > v )
     vector< vector< string > > lines;
     if ( parseDistrib( lines, v ) )
     {
+		unsigned int index = 0;
+		vector< unsigned int > chanIndices;
+		vector< unsigned int > temp;
         channelDistribution_ = v;
+		// We need to ensure that Ca_concs are created before any channels
+		// since the channels may want to connect to them.
         for ( unsigned int i = 0; i < lines.size(); ++i )
         {
-            vector< string >& temp = lines[i];
+    		Id proto( "/library/" + lines[i][0] );
+    		if ( proto != Id() ) {
+				if ( proto.element()->cinfo()->isA( "CaConcBase" ) ) {
+					chanIndices.push_back( i );
+				} else {
+					temp.push_back( i );
+				}
+			}
+		}
+		chanIndices.insert( chanIndices.end(), temp.begin(), temp.end() );
+		assert( chanIndices.size() == lines.size() );
+
+        for ( unsigned int i = 0; i < lines.size(); ++i )
+        {
+            vector< string >& temp = lines[chanIndices[i]];
             vector< ObjId > elist;
             vector< double > val;
             buildElist( e, temp, elist, val );

--- a/hsolve/HSolveActive.cpp
+++ b/hsolve/HSolveActive.cpp
@@ -63,6 +63,7 @@ void HSolveActive::step( ProcPtr info )
     sendValues( info );
     sendSpikes( info );
 
+	prevExtCurr_ = externalCurrent_;
     externalCurrent_.assign( externalCurrent_.size(), 0.0 );
 }
 

--- a/hsolve/HSolveActive.h
+++ b/hsolve/HSolveActive.h
@@ -119,6 +119,7 @@ protected:
     vector< double >          externalCurrent_; ///< External currents from
     ///< channels that HSolve
     ///< cannot internalize.
+    vector< double >          prevExtCurr_; ///< Last tick's externalCurrent
     vector< double >          externalCalcium_; /// calcium from difshells
     vector< Id >              caConcId_;		///< Used for localIndex-ing.
     vector< Id >              channelId_;		///< Used for localIndex-ing.

--- a/hsolve/HSolveActiveSetup.cpp
+++ b/hsolve/HSolveActiveSetup.cpp
@@ -584,6 +584,7 @@ void HSolveActive::readExternalChannels()
 
     //~ externalChannelId_.resize( compartmentId_.size() );
     externalCurrent_.resize( 2 * compartmentId_.size(), 0.0 );
+    prevExtCurr_.resize( externalCurrent_.size(), 0.0 );
 
     //~ for ( unsigned int ic = 0; ic < compartmentId_.size(); ++ic )
     //~ HSolveUtils::targets(

--- a/hsolve/HSolveInterface.cpp
+++ b/hsolve/HSolveInterface.cpp
@@ -170,6 +170,8 @@ double HSolve::getIm( Id id ) const
     for ( ; icurrent < currentBoundary_[ index ]; ++icurrent )
         Im += ( icurrent->Ek - V_[ index ] ) * icurrent->Gk;
 
+    assert( 2 * index + 1 < externalCurrent_.size() );
+	Im += prevExtCurr_[2*index+1] - prevExtCurr_[2*index]*V_[index];
     return Im;
 }
 


### PR DESCRIPTION
HSolve fixes: Compute Im correctly by including contributions of external (non-Hsolved) ion channels and receptors
Neuron fixes: When loading channel distributions, ensure that Ca_concs are loaded first, before any ion channels. This ensures that ion channels with dependencies on Ca_conc have something to connect to when they are built.