### PR TITLE
Hotfix | some old scripts in moose-examples failed because of regression cause by #390

### DIFF
--- a/python/moose/moose_constants.py
+++ b/python/moose/moose_constants.py
@@ -21,13 +21,9 @@ Last modified: Sat Jan 18, 2014  05:01PM
 """
 
 __author__           = "Dilawar Singh"
-__copyright__        = "Copyright 2013, Dilawar Singh, NCBS Bangalore"
-__credits__          = ["NCBS Bangalore"]
 __license__          = "GNU GPL"
-__version__          = "1.0.0"
 __maintainer__       = "Dilawar Singh"
 __email__            = "dilawars@ncbs.res.in"
-__status__           = "Development"
 
 ## for Ca Pool
 # FARADAY = 96154.0
@@ -66,4 +62,3 @@ POOLCLOCK = 3
 LOOKUPCLOCK = 6
 STIMCLOCK = 7
 PLOTCLOCK = 8
-

--- a/python/moose/moose_test.py
+++ b/python/moose/moose_test.py
@@ -62,6 +62,10 @@ class Command(object):
         try:
             timer.start()
             output, errors = self.process.communicate()
+            try:
+                errors = errors.decode('utf8')
+            except Exception:
+                pass
             logging.warn('%s %s' % (output, errors))
         finally:
             timer.cancel()

--- a/python/moose/utils.py
+++ b/python/moose/utils.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 import re
 
 import logging
-logger = logging.getLogger('moose')
+logger_ = logging.getLogger('moose')
 
 from moose.moose_constants import *
 from moose.print_utils import *
@@ -523,8 +523,11 @@ def assignDefaultTicks(modelRoot='/model', dataRoot='/data', solver='hsolve'):
             if len(tab.neighbors['input']) == 0:
                 moose.useClock(9, tab.path, 'process')
 
-def stepRun(simtime, steptime, verbose=True):
+def stepRun(simtime, steptime, verbose=True, logger=None):
     """Run the simulation in steps of `steptime` for `simtime`."""
+    global logger_
+    if logger is None:
+        logger = logger_
     clock = moose.element('/clock')
     if verbose:
         msg = 'Starting simulation for %g' % (simtime)


### PR DESCRIPTION
- Some old scripts in moose-examples failed because of regression cause by #390
- Better formatting of output when moose-examples are tested.