### PR TITLE
Bugfix | moose.Streamer streams to numpy format correctly

### DIFF
--- a/basecode/Id.cpp
+++ b/basecode/Id.cpp
@@ -76,11 +76,18 @@ string Id::id2str( Id id )
 string Id::path( const string& separator) const
 {
     string ret = Neutral::path( eref() );
-    // Trim off trailing []
-    assert( ret.length() > 0 );
-    // the 'back' operation is not supported by pre 2011 compilers
 
-    while ( ret[ ret.length() - 1 ] == ']' )
+#if 0
+    // NOTE/FIXME: Monday 09 March 2020 12:30:27 PM IST, Dilawar Singh
+    // This beaks the path comparison. Getting x.path from x returned in a 
+    // list by moose.wildcardFind() and getting path from here doesn't math
+    // when this is enabled.
+    // If we want to remove [0] then it should be done globally and not just
+    // here.
+
+    // Trim off trailing [] 
+    assert( ret.length() > 0 );
+    while ( ret.back() == ']' )
     {
         size_t pos = ret.find_last_of( '[' );
         if ( pos != string::npos && pos > 0 )
@@ -88,6 +95,7 @@ string Id::path( const string& separator) const
             ret = ret.substr( 0, pos );
         }
     }
+#endif 
 
     return ret;
 }

--- a/basecode/Id.cpp
+++ b/basecode/Id.cpp
@@ -77,8 +77,7 @@ string Id::path( const string& separator) const
 {
     string ret = Neutral::path( eref() );
 
-#if 0
-    // NOTE/FIXME: Monday 09 March 2020 12:30:27 PM IST, Dilawar Singh
+    // FIXME: Monday 09 March 2020 12:30:27 PM IST, Dilawar Singh
     // This beaks the path comparison. Getting x.path from x returned in a 
     // list by moose.wildcardFind() and getting path from here doesn't math
     // when this is enabled.
@@ -95,7 +94,6 @@ string Id::path( const string& separator) const
             ret = ret.substr( 0, pos );
         }
     }
-#endif 
 
     return ret;
 }

--- a/basecode/global.cpp
+++ b/basecode/global.cpp
@@ -18,9 +18,10 @@
 
 #include "global.h"
 #include <numeric>
+#include <regex>
+
 #include <sys/stat.h>
 #include <sys/types.h>
-
 
 /*-----------------------------------------------------------------------------
  *  This variable keep track of how many tests have been performed.
@@ -35,220 +36,251 @@ bool isRNGInitialized = false;
 
 clock_t simClock = clock();
 
-extern int checkPath( const string& path);
-extern string joinPath( string pathA, string pathB);
-extern string fixPath( string path);
-extern string dumpStats( int  );
+extern int checkPath(const string& path);
+extern string joinPath(string pathA, string pathB);
+extern string fixPath(string path);
+extern string dumpStats(int);
 
-namespace moose {
+namespace moose
+{
 
-    unsigned long __rng_seed__ = 0;
+unsigned long __rng_seed__ = 0;
 
-    map<string, valarray<double>> solverProfMap = { 
-        { "Ksolve", {0.0, 0} }, 
-        { "HSolve", {0.0, 0} }
-    };
+map<string, valarray<double>> solverProfMap = {{"Ksolve", {0.0, 0}},
+    {"HSolve", {0.0, 0}}
+};
 
-    moose::RNG rng;
+moose::RNG rng;
 
-    /* Check if path is OK */
-    int checkPath( const string& path  )
+/* Check if path is OK */
+int checkPath(const string& path)
+{
+    if (path.size() < 1)
+        return EMPTY_PATH;
+
+    if (path.find_first_of(" \\!") != std::string::npos)
+        return BAD_CHARACTER_IN_PATH;
+
+    if (path[path.size() - 1] != ']')
     {
-        if( path.size() < 1)
-            return EMPTY_PATH;
-
-        if( path.find_first_of( " \\!") != std::string::npos )
-            return BAD_CHARACTER_IN_PATH;
-
-        if ( path[path.size() - 1 ] != ']')
-        {
-            return MISSING_BRACKET_AT_END;
-        }
-        return 0;
+        return MISSING_BRACKET_AT_END;
     }
+    return 0;
+}
 
-    /* Join paths */
-    string joinPath( string pathA, string pathB )
-    {
-        pathA = moose::fixPath( pathA );
-        string newPath = pathA + "/" + pathB;
-        return moose::fixPath( newPath );
-    }
+/* Join paths */
+string joinPath(string pathA, string pathB)
+{
+    pathA = moose::fixPath(pathA);
+    string newPath = pathA + "/" + pathB;
+    return moose::fixPath(newPath);
+}
 
-    /* Fix given path */
-    string fixPath(string path)
-    {
-        int pathOk = moose::checkPath( path );
-        if( pathOk == 0)
-            return path;
-        else if( pathOk == MISSING_BRACKET_AT_END)
-            return path + "[0]";
+/* Fix given path */
+string fixPath(string path)
+{
+    int pathOk = moose::checkPath(path);
+    if (pathOk == 0)
         return path;
-    }
+    else if (pathOk == MISSING_BRACKET_AT_END)
+        return path + "[0]";
+    return path;
+}
 
-    /**
-     * @brief Set the global seed or all rngs.
-     *
-     * @param x
-     */
-    void mtseed( unsigned int x )
+/**
+ * @brief Set the global seed or all rngs.
+ *
+ * @param x
+ */
+void mtseed(unsigned int x)
+{
+    moose::__rng_seed__ = x;
+    moose::rng.setSeed(x);
+    isRNGInitialized = true;
+}
+
+/*  Generate a random number */
+double mtrand(void)
+{
+    return moose::rng.uniform();
+}
+
+double mtrand(double a, double b)
+{
+    return (b - a) * mtrand() + a;
+}
+
+// MOOSE suffixes [0] to all elements to path. Remove [0] with null
+// character whenever possible. For n > 0, [n] should not be touched. Its
+// the user job to take the pain and write the correct path.
+string createMOOSEPath(const string& path)
+{
+    string s = path; /* Local copy */
+    // Remove [0] from paths. They will be annoying for normal users.
+    std::string::size_type n = 0;
+    string zeroIndex("[0]");
+    while ((n = s.find(zeroIndex, n)) != std::string::npos)
+        s.erase(n, zeroIndex.size());
+    return s;
+}
+
+/**
+ * @brief Create directories recursively needed to open the given file p.
+ *
+ * @param path When successfully created, returns created path, else
+ * convert path to a filename by replacing '/' by '_'.
+ */
+bool createParentDirs(const string& path)
+{
+    // Remove the filename from the given path so we only have the
+    // directory.
+    string p = path;
+    bool failed = false;
+    size_t pos = p.find_last_of('/');
+    if (pos != std::string::npos)
+        p = p.substr(0, pos);
+    else /* no parent directory to create */
+        return true;
+
+    if (p.size() == 0)
+        return true;
+
+    string command("mkdir -p ");
+    command += p;
+    int ret = system(command.c_str());
+    struct stat info;
+    if (stat(p.c_str(), &info) != 0)
     {
-        moose::__rng_seed__ = x;
-        moose::rng.setSeed( x );
-        isRNGInitialized = true;
+        LOG(moose::warning, "cannot access " << p);
+        return false;
     }
-
-    /*  Generate a random number */
-    double mtrand( void )
+    else if (info.st_mode & S_IFDIR)
     {
-        return moose::rng.uniform( );
-    }
-
-    double mtrand( double a, double b )
-    {
-        return (b-a) * mtrand() + a; 
-    }
-
-    // MOOSE suffixes [0] to all elements to path. Remove [0] with null
-    // character whenever possible. For n > 0, [n] should not be touched. Its
-    // the user job to take the pain and write the correct path.
-    string createMOOSEPath( const string& path )
-    {
-        string s = path;                        /* Local copy */
-        // Remove [0] from paths. They will be annoying for normal users.
-        std::string::size_type n = 0;
-        string zeroIndex("[0]");
-        while( (n = s.find( zeroIndex, n )) != std::string::npos )
-            s.erase( n, zeroIndex.size() );
-        return s;
-    }
-
-    /**
-     * @brief Create directories recursively needed to open the given file p.
-     *
-     * @param path When successfully created, returns created path, else
-     * convert path to a filename by replacing '/' by '_'.
-     */
-    bool createParentDirs( const string& path )
-    {
-        // Remove the filename from the given path so we only have the
-        // directory.
-        string p = path;
-        bool failed = false;
-        size_t pos = p.find_last_of( '/' );
-        if( pos != std::string::npos )
-            p = p.substr( 0, pos );
-        else                                    /* no parent directory to create */
-            return true;
-
-        if( p.size() == 0 )
-            return true;
-
-#ifdef  USE_BOOST_FILESYSTEM
-        try
-        {
-            boost::filesystem::path pdirs( p );
-            boost::filesystem::create_directories( pdirs );
-            LOG( moose::info, "Created directory " << p );
-            return true;
-        }
-        catch(const boost::filesystem::filesystem_error& e)
-        {
-            LOG( moose::warning, "create_directories(" << p << ") failed with "
-                    << e.code().message()
-               );
-            return false;
-        }
-#else      /* -----  not USE_BOOST_FILESYSTEM  ----- */
-        string command( "mkdir -p ");
-        command += p;
-        int ret = system( command.c_str() );
-        struct stat info;
-        if( stat( p.c_str(), &info ) != 0 )
-        {
-            LOG( moose::warning, "cannot access " << p );
-            return false;
-        }
-        else if( info.st_mode & S_IFDIR )
-        {
-            LOG( moose::info, "Created directory " <<  p );
-            return true;
-        }
-        else
-        {
-            LOG( moose::warning, p << " is no directory" );
-            return false;
-        }
-#endif     /* -----  not USE_BOOST_FILESYSTEM  ----- */
+        LOG(moose::info, "Created directory " << p);
         return true;
     }
-
-
-    /*  Flatten a dir-name to return a filename which can be created in pwd . */
-    string toFilename( const string& path )
+    else
     {
-        string p = path;
-        std::replace(p.begin(), p.end(), '/', '_' );
-        std::replace(p.begin(), p.end(), '\\', '_' );
-        return p;
+        LOG(moose::warning, p << " is no directory");
+        return false;
     }
+    return true;
+}
 
-    /*  return extension of a filename */
-    string getExtension(const string& path, bool without_dot )
+/*  Flatten a dir-name to return a filename which can be created in pwd . */
+string toFilename(const string& path)
+{
+    string p = path;
+    std::replace(p.begin(), p.end(), '/', '_');
+    std::replace(p.begin(), p.end(), '\\', '_');
+    return p;
+}
+
+/*  return extension of a filename */
+string getExtension(const string& path, bool without_dot)
+{
+    size_t dotPos = path.find_last_of('.');
+    if (dotPos == std::string::npos)
+        return "";
+
+    if (without_dot)
+        return path.substr(dotPos + 1);
+
+    return path.substr(dotPos);
+}
+
+/*  returns `basename path`  */
+string pathToName(const string& path)
+{
+    return path.substr(path.find_last_of('/'));
+}
+
+/*  /a[0]/b[1]/c[0] -> /a/b/c  */
+string moosePathToUserPath(string path)
+{
+    // Just write the moose path. Things becomes messy when indexing is
+    // used.
+    return createMOOSEPath(path);
+}
+
+/* --------------------------------------------------------------------------*/
+/**
+ * @Synopsis  Generate a suitable column name based on given path. Replace
+ * [\d+] with \d+; and remove [\0+]. Replace / with given delim (default '.')
+ *
+ * @Param path (string).
+ * @Param delim (char)
+ * @Param maxLevel  (int). Max number of parents to include. Default 1.
+ *
+ * @Returns  Reformatted path suitable for column name.
+ *
+ * Example:
+ * -------
+ *      /a[12]/d[0]/e[1]/d[0] -> e1.d
+ *      /a[12]/d[0] -> e12.d
+ *      /a[00]/b[0] -> a.b
+ */
+/* ----------------------------------------------------------------------------*/
+string moosePathToColumnName(const string& path, char delim, size_t maxParents)
+{
+    string s(path);
+    static std::regex e0("\\[(0+)\\]");    // Remove [0+]
+    static std::regex e1("\\[(\\d+)\\]");  // Replace [xyz] by xyz
+    s = std::regex_replace(s, e0, "");
+    s = std::regex_replace(s, e1, "$1");
+
+    string s2;
+    string colname = "";
+    size_t nBreak = 0;
+
+    // Keep as many parents as required by maxParents. Using reverse magic.
+    for (auto rit = s.rbegin(); rit != s.rend(); rit++)
     {
-        size_t dotPos = path.find_last_of( '.' );
-        if( dotPos == std::string::npos )
-            return "";
-
-        if( without_dot )
-            return path.substr( dotPos + 1 );
-
-        return path.substr( dotPos );
+        if (*rit == '/')
+        {
+            colname = s2 + delim + colname;
+            s2 = "";
+            nBreak += 1;
+            if (nBreak == (1 + maxParents))
+                break;
+        }
+        else
+            s2 = *rit + s2;
     }
+    colname.pop_back();
+    return colname;
+}
 
-    /*  returns `basename path`  */
-    string pathToName( const string& path )
-    {
-        return path.substr( path.find_last_of( '/' ) );
-    }
+/*  Return formatted string
+ *  Precision is upto 17 decimal points.
+ */
+string toString(double x)
+{
+    char buffer[50];
+    sprintf(buffer, "%.17g", x);
+    return string(buffer);
+}
 
-    /*  /a[0]/b[1]/c[0] -> /a/b/c  */
-    string moosePathToUserPath( string path )
-    {
-        // Just write the moose path. Things becomes messy when indexing is
-        // used.
-        return createMOOSEPath( path );
-    }
+int getGlobalSeed()
+{
+    return __rng_seed__;
+}
 
-    /*  Return formatted string
-     *  Precision is upto 17 decimal points.
-     */
-    string toString( double x )
-    {
-        char buffer[50];
-        sprintf(buffer, "%.17g", x );
-        return string( buffer );
-    }
+void setGlobalSeed(int seed)
+{
+    __rng_seed__ = seed;
+}
 
-    int getGlobalSeed( )
-    {
-        return __rng_seed__;
-    }
+void addSolverProf(const string& name, double time, size_t steps)
+{
+    solverProfMap[name] =
+        solverProfMap[name] + valarray<double>({time, (double)steps});
+}
 
-    void setGlobalSeed( int seed )
-    {
-        __rng_seed__ = seed;
-    }
-
-    void addSolverProf( const string& name, double time, size_t steps)
-    {
-        solverProfMap[ name ] = solverProfMap[name] + valarray<double>({ time, (double)steps });
-    }
-
-    void printSolverProfMap( )
-    {
-        for( auto &v : solverProfMap )
-            cout <<  '\t' << v.first << ": " << v.second[0] << " sec (" << v.second[1] << ")" << endl;
-    }
-
+void printSolverProfMap()
+{
+    for (auto& v : solverProfMap)
+        cout << '\t' << v.first << ": " << v.second[0] << " sec ("
+             << v.second[1] << ")" << endl;
+}
 }

--- a/basecode/global.h
+++ b/basecode/global.h
@@ -8,21 +8,15 @@
 ** See the file COPYING.LIB for the full notice.
 **********************************************************************/
 
-
-#ifndef  __MOOSE_GLOBAL_INC_
-#define  __MOOSE_GLOBAL_INC_
+#ifndef __MOOSE_GLOBAL_INC_
+#define __MOOSE_GLOBAL_INC_
 
 #include <ctime>
 #include <map>
 #include <sstream>
 #include <valarray>
 
-
-#ifdef  USE_BOOST_FILESYSTEM
-#include <boost/filesystem.hpp>
-#endif
-
-#include "randnum/RNG.h"                        /* Use inbuilt rng */
+#include "../randnum/RNG.h" /* Use inbuilt rng */
 #include "../utility/print_function.hpp"
 
 using namespace std;
@@ -37,23 +31,24 @@ extern stringstream errorSS;
  */
 extern unsigned int totalTests;
 
-
 /** @brief This macro prints the output of a test function onto console.  It
  * also keep track of index of the current test. The index of test is
  * automatically computed by increamenting the counter.
  */
 
-#define TEST_BEGIN cout << endl << "Test(" << totalTests << "): " << SIMPLE_CURRENT_FUNCTION;
-#define TEST_END totalTests++; \
-    cout << std::right <<  setw(20) << "test of " << SIMPLE_CURRENT_FUNCTION << " finished.";
+#define TEST_BEGIN \
+    cout << endl << "Test(" << totalTests << "): " << SIMPLE_CURRENT_FUNCTION;
+#define TEST_END                                                            \
+    totalTests++;                                                           \
+    cout << std::right << setw(20) << "test of " << SIMPLE_CURRENT_FUNCTION \
+         << " finished.";
 
-#define MISSING_BRACKET_AT_END                  -1
-#define EMPTY_PATH                              -2
-#define SPACES_AT_THE_BEGINING                  -3
-#define SPACES_AT_THE_END                       -4
-#define SPACES_IN_BETWEEN                       -5
-#define BAD_CHARACTER_IN_PATH                   -6
-
+#define MISSING_BRACKET_AT_END -1
+#define EMPTY_PATH -2
+#define SPACES_AT_THE_BEGINING -3
+#define SPACES_AT_THE_END -4
+#define SPACES_IN_BETWEEN -5
+#define BAD_CHARACTER_IN_PATH -6
 
 /*-----------------------------------------------------------------------------
  *  Global functions in namespace moose
@@ -61,171 +56,180 @@ extern unsigned int totalTests;
 namespace moose
 {
 
-    extern moose::RNG rng;
+extern moose::RNG rng;
 
-    extern map<string, valarray<double>> solverProfMap;
+extern map<string, valarray<double>> solverProfMap;
 
-    /**
-     * @brief A global seed for all RNGs in moose. When moose.seed( x ) is called,
-     * this variable is set. Other's RNGs (except muparser) uses this seed to
-     * initialize them. By default it is initialized by random_device (see
-     * global.cpp).
-     */
-    extern unsigned long __rng_seed__;
+/**
+ * @brief A global seed for all RNGs in moose. When moose.seed( x ) is called,
+ * this variable is set. Other's RNGs (except muparser) uses this seed to
+ * initialize them. By default it is initialized by random_device (see
+ * global.cpp).
+ */
+extern unsigned long __rng_seed__;
 
-    /**
-     * @brief Fix a path. For testing purpose.
-     *
-     * @param path Path as string.
-     *
-     * @return  A fixed path.
-     */
-    string fixPath(string path);
+/**
+ * @brief Fix a path. For testing purpose.
+ *
+ * @param path Path as string.
+ *
+ * @return  A fixed path.
+ */
+string fixPath(string path);
 
-    /**
-     * @brief Checks if given path is correct.
-     * If not, return false and error-code as well.
-     *
-     * @param path Path name.
-     *
-     * @return 0 if path is all-right. Negative number if path is not OK.
-     */
-    int checkPath( const string& path );
+/**
+ * @brief Checks if given path is correct.
+ * If not, return false and error-code as well.
+ *
+ * @param path Path name.
+ *
+ * @return 0 if path is all-right. Negative number if path is not OK.
+ */
+int checkPath(const string& path);
 
-    /** @brief Append pathB to pathA and return the result.
-     *
-     * If pathA does not have [indexs] at the end, append "[0]" to pathA and
-     * then add pathB to it.  This version does not care if the result has '[0]'
-     * at its end.
-     *
-     * @param pathA First path.
-     * @param pathB Second path.
-     *
-     * @return A string representing moose-path.
-     */
-    string joinPath(string pathA, string pathB);
+/** @brief Append pathB to pathA and return the result.
+ *
+ * If pathA does not have [indexs] at the end, append "[0]" to pathA and
+ * then add pathB to it.  This version does not care if the result has '[0]'
+ * at its end.
+ *
+ * @param pathA First path.
+ * @param pathB Second path.
+ *
+ * @return A string representing moose-path.
+ */
+string joinPath(string pathA, string pathB);
 
-    /**
-     * @brief Seed seed for RNG.
-     *
-     * @param seed
-     */
-    void mtseed( unsigned int seed );
+/**
+ * @brief Seed seed for RNG.
+ *
+ * @param seed
+ */
+void mtseed(unsigned int seed);
 
-    /**
-     * @brief Generate a random double between 0 and 1
-     *
-     * @return  A random number between 0 and 1.
-     */
-    double mtrand( void );
+/**
+ * @brief Generate a random double between 0 and 1
+ *
+ * @return  A random number between 0 and 1.
+ */
+double mtrand(void);
 
-    /* --------------------------------------------------------------------------*/
-    /**
-     * @Synopsis  Overloaded function. Random number between a and b
-     *
-     * @Param a lower limit.
-     * @Param b Upper limit.
-     *
-     * @Returns   
-     */
-    /* ----------------------------------------------------------------------------*/
-    double mtrand( double a, double b );
+/* --------------------------------------------------------------------------*/
+/**
+ * @Synopsis  Overloaded function. Random number between a and b
+ *
+ * @Param a lower limit.
+ * @Param b Upper limit.
+ *
+ * @Returns
+ */
+/* ----------------------------------------------------------------------------*/
+double mtrand(double a, double b);
 
-    /**
-     * @brief Create a POSIX compatible path from a given string.
-     * Remove/replace bad characters.
-     *
-     * @param path Reutrn path is given path if creation was successful, else
-     * directory is renamed to a filename.
-     */
-    string createMOOSEPath( const string& path );
+/**
+ * @brief Create a POSIX compatible path from a given string.
+ * Remove/replace bad characters.
+ *
+ * @param path Reutrn path is given path if creation was successful, else
+ * directory is renamed to a filename.
+ */
+string createMOOSEPath(const string& path);
 
-    /**
-     * @brief Convert a given value to string.
-     *
-     * @tparam T
-     * @param x
-     *
-     * @return  String representation
-     */
-    string toString( double x );
+/**
+ * @brief Convert a given value to string.
+ *
+ * @tparam T
+ * @param x
+ *
+ * @return  String representation
+ */
+string toString(double x);
 
-    /**
-     * @brief Create directory, recursively.
-     */
-    bool createParentDirs( const string& path );
+/**
+ * @brief Create directory, recursively.
+ */
+bool createParentDirs(const string& path);
 
-    /**
-     * @brief Replace all directory sepearator with _. This creates a filepath
-     * which can be created in current directory without any need to create
-     * parent directory.
-     *
-     * @param path string
-     *
-     * @return  filename without directory separator.
-     */
-    string toFilename( const string& path );
+/**
+ * @brief Replace all directory sepearator with _. This creates a filepath
+ * which can be created in current directory without any need to create
+ * parent directory.
+ *
+ * @param path string
+ *
+ * @return  filename without directory separator.
+ */
+string toFilename(const string& path);
 
-    /**
-     * @brief Get the extension of a given filepath.
-     *
-     * @param path Given path.
-     *
-     * @return Extension (with or without preceeding '.' )
-     */
-    string getExtension( const string& path, bool without_dot = true );
+/**
+ * @brief Get the extension of a given filepath.
+ *
+ * @param path Given path.
+ *
+ * @return Extension (with or without preceeding '.' )
+ */
+string getExtension(const string& path, bool without_dot = true);
 
-    /**
-     * @brief Return the name when path is given. Its behaviour is exactly the
-     * same as of `basename`  command on unix system.
-     *
-     * @param path
-     *
-     * @return  name.
-     */
-    string pathToName( const string& path );
+/**
+ * @brief Return the name when path is given. Its behaviour is exactly the
+ * same as of `basename`  command on unix system.
+ *
+ * @param path
+ *
+ * @return  name.
+ */
+string pathToName(const string& path);
 
-    /**
-     * @brief When user gives a path /a/b/c, moose creates a path
-     * /a[0]/b[0]/c[0]. This is helpful in cases where one needs to create more
-     * than 1 element.
-     *
-     * @param path Removed '[0]' from path and return.
-     *
-     * @return
-     */
-    string moosePathToUserPath( string path );
+/**
+ * @brief When user gives a path /a/b/c, moose creates a path
+ * /a[0]/b[0]/c[0]. This is helpful in cases where one needs to create more
+ * than 1 element.
+ *
+ * @param path Removed '[0]' from path and return.
+ *
+ * @return
+ */
+string moosePathToUserPath(string path);
 
-    /* --------------------------------------------------------------------------*/
-    /**
-     * @Synopsis  Get the global seed set by call of moose.seed( X )
-     *
-     * @Returns  seed (int).
-     */
-    /* ----------------------------------------------------------------------------*/
-    int getGlobalSeed( );
+/* --------------------------------------------------------------------------*/
+/**
+ * @Synopsis  Genearate a suitable string for column name which can be used
+ * in a spreadsheet/numpy table/csv file etc.
+ */
+/* ----------------------------------------------------------------------------*/
+string moosePathToColumnName(const string& path, char delim = '.',
+                             size_t maxParents = 1);
 
-    /* --------------------------------------------------------------------------*/
-    /**
-     * @Synopsis  Set the seed for all random generator. When seed of a RNG is
-     * not set, this seed it used. It is set to -1 by default.
-     *
-     * @Param seed
-     */
-    /* ----------------------------------------------------------------------------*/
-    void setGlobalSeed( int seed );
+/* --------------------------------------------------------------------------*/
+/**
+ * @Synopsis  Get the global seed set by call of moose.seed( X )
+ *
+ * @Returns  seed (int).
+ */
+/* ----------------------------------------------------------------------------*/
+int getGlobalSeed();
 
-    /* --------------------------------------------------------------------------*/
-    /**
-     * @Synopsis  Add solver performance into the global map.
-     *
-     * @Param name Name of the solver.
-     * @Param time Time taken by the solver.
-     * @Param steps Steps.
-     */
-    /* ----------------------------------------------------------------------------*/
-    void addSolverProf( const string& name, double time, size_t steps = 1);
-    void printSolverProfMap( );
+/* --------------------------------------------------------------------------*/
+/**
+ * @Synopsis  Set the seed for all random generator. When seed of a RNG is
+ * not set, this seed it used. It is set to -1 by default.
+ *
+ * @Param seed
+ */
+/* ----------------------------------------------------------------------------*/
+void setGlobalSeed(int seed);
+
+/* --------------------------------------------------------------------------*/
+/**
+ * @Synopsis  Add solver performance into the global map.
+ *
+ * @Param name Name of the solver.
+ * @Param time Time taken by the solver.
+ * @Param steps Steps.
+ */
+/* ----------------------------------------------------------------------------*/
+void addSolverProf(const string& name, double time, size_t steps = 1);
+void printSolverProfMap();
 }
 
-#endif   /* ----- #ifndef __MOOSE_GLOBAL_INC_  ----- */
+#endif /* ----- #ifndef __MOOSE_GLOBAL_INC_  ----- */

--- a/builtins/Streamer.cpp
+++ b/builtins/Streamer.cpp
@@ -185,10 +185,10 @@ void Streamer::reinit(const Eref& e, ProcPtr p)
             if( tick != tableDt_[0] )
             {
                 moose::showWarn( "Table " + tableIds_[i].path() + " has "
-                        " different clock dt. "
-                        " Make sure all tables added to Streamer have the same "
-                        " dt value."
-                        );
+                                 " different clock dt. "
+                                 " Make sure all tables added to Streamer have the same "
+                                 " dt value."
+                               );
             }
         }
     }
@@ -209,12 +209,12 @@ void Streamer::reinit(const Eref& e, ProcPtr p)
         if( tableTick_[i] != tableTick_[0] )
         {
             LOG( moose::warning
-                    , "Table " << tableIds_[i].path()
-                    << " has tick (dt) which is different than the first table."
-                    << endl
-                    << " Got " << tableTick_[i] << " expected " << tableTick_[0]
-                    << endl << " Disabling this table."
-                    );
+                 , "Table " << tableIds_[i].path()
+                 << " has tick (dt) which is different than the first table."
+                 << endl
+                 << " Got " << tableTick_[i] << " expected " << tableTick_[0]
+                 << endl << " Disabling this table."
+               );
             invalidTables.push_back( i );
         }
     }
@@ -236,7 +236,7 @@ void Streamer::reinit(const Eref& e, ProcPtr p)
     // write now.
     currTime_ = 0.0;
     zipWithTime( );
-    StreamerBase::writeToOutFile(outfilePath_, format_, "w", data_, columns_);
+    StreamerBase::writeToOutFile(outfilePath_, format_, WRITE, data_, columns_);
     data_.clear( );
 }
 
@@ -247,7 +247,7 @@ void Streamer::reinit(const Eref& e, ProcPtr p)
 void Streamer::cleanUp( )
 {
     zipWithTime( );
-    StreamerBase::writeToOutFile( outfilePath_, format_, "a", data_, columns_ );
+    StreamerBase::writeToOutFile( outfilePath_, format_, APPEND, data_, columns_ );
     data_.clear( );
 }
 
@@ -261,7 +261,7 @@ void Streamer::process(const Eref& e, ProcPtr p)
 {
     // LOG( moose::debug, "Writing Streamer data to file." );
     zipWithTime( );
-    StreamerBase::writeToOutFile( outfilePath_, format_, "a", data_, columns_ );
+    StreamerBase::writeToOutFile( outfilePath_, format_, APPEND, data_, columns_ );
     data_.clear();
     numWriteEvents_ += 1;
 }
@@ -284,12 +284,12 @@ void Streamer::addTable( Id table )
     tables_.push_back( t );
     tableTick_.push_back( table.element()->getTick() );
 
-    // NOTE: If user can make sure that names are unique in table, using name is
-    // better than using the full path.
-    if( t->getColumnName().size() > 0 )
-        columns_.push_back( t->getColumnName( ) );
+    // NOTE: Table can also have name. If name is set by User, use the name to
+    // for column name, else use full path of the table.
+    if(t->getColumnName().size() > 0)
+        columns_.push_back(t->getColumnName());
     else
-        columns_.push_back( moose::moosePathToUserPath( table.path() ) );
+        columns_.push_back(table.path());
 }
 
 /**
@@ -355,7 +355,7 @@ size_t Streamer::getNumTables( void ) const
  * @Synopsis  Get number of write events in streamer. Useful for debugging and
  * performance measuerments.
  *
- * @Returns   
+ * @Returns
  */
 /* ----------------------------------------------------------------------------*/
 size_t Streamer::getNumWriteEvents( void ) const
@@ -414,8 +414,8 @@ void Streamer::zipWithTime( )
         {
 #if 0
             LOG( moose::debug
-                    , "Table " << tables_[i]->getName( ) << " is not functional. Filling with zero "
-                    );
+                 , "Table " << tables_[i]->getName( ) << " is not functional. Filling with zero "
+               );
 #endif
             tVec.resize( numEntriesInEachTable, 0 );
         }

--- a/builtins/Streamer.cpp
+++ b/builtins/Streamer.cpp
@@ -21,13 +21,21 @@ const Cinfo* Streamer::initCinfo()
     /*-----------------------------------------------------------------------------
      * Finfos
      *-----------------------------------------------------------------------------*/
-    static ValueFinfo< Streamer, string > outfile(
-        "outfile"
+    static ValueFinfo< Streamer, string > datafile(
+        "datafile"
         , "File/stream to write table data to. Default is is __moose_tables__.dat.n"
         " By default, this object writes data every second \n"
-        , &Streamer::setOutFilepath
-        , &Streamer::getOutFilepath
+        , &Streamer::setDatafilePath
+        , &Streamer::getDatafilePath
     );
+
+    static ValueFinfo< Streamer, string > outfile(
+        "outfile"
+        , "Use datafile (deprecated)"
+        , &Streamer::setDatafilePath
+        , &Streamer::getDatafilePath
+    );
+
 
     static ValueFinfo< Streamer, string > format(
         "format"
@@ -104,7 +112,7 @@ const Cinfo* Streamer::initCinfo()
 
     static Finfo * tableStreamFinfos[] =
     {
-        &outfile, &format, &proc, &numTables, &numWriteEvents
+        &datafile, &outfile, &format, &proc, &numTables, &numWriteEvents
     };
 
     static string doc[] =
@@ -229,14 +237,14 @@ void Streamer::reinit(const Eref& e, ProcPtr p)
     if( ! isOutfilePathSet_ )
     {
         string defaultPath = "_tables/" + moose::moosePathToUserPath( e.id().path() );
-        setOutFilepath( defaultPath );
+        setDatafilePath( defaultPath );
     }
 
     // Prepare data. Add columns names and write whatever values are available
     // write now.
     currTime_ = 0.0;
     zipWithTime( );
-    StreamerBase::writeToOutFile(outfilePath_, format_, WRITE, data_, columns_);
+    StreamerBase::writeToOutFile(datafilePath_, format_, WRITE, data_, columns_);
     data_.clear( );
 }
 
@@ -247,7 +255,7 @@ void Streamer::reinit(const Eref& e, ProcPtr p)
 void Streamer::cleanUp( )
 {
     zipWithTime( );
-    StreamerBase::writeToOutFile( outfilePath_, format_, APPEND, data_, columns_ );
+    StreamerBase::writeToOutFile( datafilePath_, format_, APPEND, data_, columns_ );
     data_.clear( );
 }
 
@@ -261,7 +269,7 @@ void Streamer::process(const Eref& e, ProcPtr p)
 {
     // LOG( moose::debug, "Writing Streamer data to file." );
     zipWithTime( );
-    StreamerBase::writeToOutFile( outfilePath_, format_, APPEND, data_, columns_ );
+    StreamerBase::writeToOutFile( datafilePath_, format_, APPEND, data_, columns_ );
     data_.clear();
     numWriteEvents_ += 1;
 }
@@ -285,11 +293,12 @@ void Streamer::addTable( Id table )
     tableTick_.push_back( table.element()->getTick() );
 
     // NOTE: Table can also have name. If name is set by User, use the name to
-    // for column name, else use full path of the table.
+    // for column name, else use modify the table path to generate a suitable
+    // column name.
     if(t->getColumnName().size() > 0)
         columns_.push_back(t->getColumnName());
     else
-        columns_.push_back(table.path());
+        columns_.push_back(moose::moosePathToColumnName(table.path()));
 }
 
 /**
@@ -364,19 +373,19 @@ size_t Streamer::getNumWriteEvents( void ) const
 }
 
 
-string Streamer::getOutFilepath( void ) const
+string Streamer::getDatafilePath( void ) const
 {
-    return outfilePath_;
+    return datafilePath_;
 }
 
-void Streamer::setOutFilepath( string filepath )
+void Streamer::setDatafilePath( string filepath )
 {
-    outfilePath_ = filepath;
+    datafilePath_ = filepath;
     isOutfilePathSet_ = true;
     if( ! moose::createParentDirs( filepath ) )
-        outfilePath_ = moose::toFilename( outfilePath_ );
+        datafilePath_ = moose::toFilename( datafilePath_ );
 
-    string format = moose::getExtension( outfilePath_, true );
+    string format = moose::getExtension( datafilePath_, true );
     if( format.size() > 0)
         setFormat( format );
     else

--- a/builtins/Streamer.h
+++ b/builtins/Streamer.h
@@ -42,8 +42,8 @@ public:
     /* Cleaup before quitting */
     void cleanUp( void );
 
-    string getOutFilepath( void ) const;
-    void setOutFilepath( string path );
+    string getDatafilePath( void ) const;
+    void setDatafilePath( string path );
 
     string getFormat( void ) const;
     void setFormat( string format );
@@ -73,7 +73,7 @@ public:
 
 private:
 
-    string outfilePath_;
+    string datafilePath_;
     string format_;
 
     size_t numWriteEvents_;

--- a/builtins/StreamerBase.h
+++ b/builtins/StreamerBase.h
@@ -28,6 +28,8 @@ using namespace std;
 
 class TableBase;
 
+enum OpenMode {WRITE, APPEND, WRITE_STR, APPEND_STR, WRITE_BIN, APPEND_BIN};
+
 class StreamerBase : public TableBase
 {
 
@@ -63,7 +65,7 @@ public:
      */
     static void writeToOutFile(
             const string& filepath, const string& format
-            , const string& openmode
+            , const OpenMode openmode
             , const vector<double>& data
             , const vector<string>& columns
             );
@@ -72,7 +74,7 @@ public:
      * @brief Write data to csv file. See the documentation of writeToOutfile
      * for details.
      */
-    static void writeToCSVFile( const string& filepath, const string& openmode
+    static void writeToCSVFile( const string& filepath, const OpenMode openMode
             , const vector<double>& data, const vector<string>& columns
             );
 
@@ -80,7 +82,7 @@ public:
      * @brief  Write to NPY format. See the documentation of
      * writeToOutfile for more details.
      */
-    static void writeToNPYFile( const string& filepath, const string& openmode
+    static void writeToNPYFile( const string& filepath, const OpenMode openmode
             , const vector<double>& data
             , const vector<string>& columns
             );

--- a/builtins/Table.cpp
+++ b/builtins/Table.cpp
@@ -228,7 +228,7 @@ Table::~Table( )
     if( useFileStreamer_ )
     {
         mergeWithTime( data_ );
-        StreamerBase::writeToOutFile( outfile_, format_, "a", data_, columns_ );
+        StreamerBase::writeToOutFile( outfile_, format_, APPEND, data_, columns_ );
         clearAllVecs();
     }
 }
@@ -269,7 +269,7 @@ void Table::process( const Eref& e, ProcPtr p )
         if( fmod(lastTime_, 5.0) == 0.0 || getVecSize() >= 10000 )
         {
             mergeWithTime( data_ );
-            StreamerBase::writeToOutFile( outfile_, format_, "a", data_, columns_ );
+            StreamerBase::writeToOutFile( outfile_, format_, APPEND, data_, columns_ );
             clearAllVecs();
         }
         }
@@ -332,7 +332,7 @@ void Table::reinit( const Eref& e, ProcPtr p )
     if( useFileStreamer_ )
     {
         mergeWithTime( data_ );
-        StreamerBase::writeToOutFile( outfile_, format_, "w", data_, columns_);
+        StreamerBase::writeToOutFile( outfile_, format_, WRITE, data_, columns_);
         clearAllVecs();
     }
 }

--- a/builtins/Table.h
+++ b/builtins/Table.h
@@ -10,11 +10,7 @@
 #ifndef _TABLE_H
 #define _TABLE_H
 
-
-#if  USE_BOOST_FILESYSTEM
-#include <boost/filesystem.hpp>
-#endif     /* -----  USE_BOOST_FILESYSTEM  ----- */
-#include <fstream>
+using namespace std;
 
 /**
  * Receives and records inputs. Handles plot and spiking data in batch mode.
@@ -46,8 +42,8 @@ public:
     void setUseSpikeMode ( bool status );
     bool getUseSpikeMode ( void ) const;
 
-    void setOutfile ( string outfilepath );
-    string getOutfile ( void ) const;
+    void setDatafile ( string filepath );
+    string getDatafile ( void ) const;
 
     // Access the dt_ of table.
     double getDt ( void ) const;
@@ -88,7 +84,14 @@ private:
 
     vector<double> data_;
     vector<double> tvec_;                       /* time data */
-    vector<string> columns_;                    /* Store the name of tables */
+
+    // A table have 2 columns. First is time. We initialize this in reinit().
+    vector<string> columns_; 
+
+    /**
+     * @brief dt of its clock. Needed for creating time co-ordinates,
+     */
+    double dt_;
 
     // Upto which indices we have read the data. This variable is used when
     // SocketStreamer is used.
@@ -102,45 +105,20 @@ private:
     string tableColumnName_;
 
     /**
-     * @brief If stream is set to true, then stream to outfile_. Default value
-     * of outfile_ is table path starting from `pwd`/_tables_ . On table, set
+     * @brief If stream is set to true, then stream to datafile_. Default value
+     * of datafile_ is table path starting from `pwd`/_tables_ . On table, set
      * streamToFile to true.
      */
     bool useFileStreamer_;
 
-    /**
-     * @brief Table directory into which dump the stream data.
-     */
-    string rootdir_;
-
-    // On Table, set outfile to change this variable. By default it sets to,
+    // On Table, set datafile to change this variable. By default it sets to,
     // `pwd1/_tables_/table.path().
-    string outfile_;
-
-    /**
-     * @brief Wheather or not outfile path is set by user
-     */
-    bool outfileIsSet_;
+    string datafile_;
 
     /**
      * @brief format of data. Default to csv.
      */
     string format_;
-
-    /**
-     * @brief text_ to write.
-     */
-    string text_;
-
-    /**
-     * @brief dt of its clock. Needed for creating time co-ordinates,
-     */
-    double dt_;
-
-    /**
-     * @brief Output stream.
-     */
-    std::ofstream of_;
 
 };
 

--- a/pymoose/CMakeLists.txt
+++ b/pymoose/CMakeLists.txt
@@ -59,8 +59,7 @@ execute_process( COMMAND ${PYTHON_EXECUTABLE}-config --libs
 
 set_target_properties(_moose PROPERTIES
     COMPILE_DEFINITIONS "PYMOOSE"
-  COMPILE_FLAGS "${COMPILE_FLAGS} ${PYTHON_INCLUDE_FLAGS}"
-    )
+    COMPILE_FLAGS "${COMPILE_FLAGS} ${PYTHON_INCLUDE_FLAGS}")
 
 # Remove prefix lib from python module.
 if(NOT(PYTHON_SO_EXTENSION STREQUAL ""))

--- a/python/moose/neuroml2/reader.py
+++ b/python/moose/neuroml2/reader.py
@@ -4,25 +4,21 @@ from __future__ import print_function, division, absolute_import
 # Description: NeuroML2 reader.
 #     Implementation of reader for NeuroML 2 models.
 #     TODO: handle morphologies of more than one segment...
+#
 # Author: Subhasis Ray, Padraig Gleeson
-# Maintainer:  Dilawar Singh <dilawars@ncbs.res.in>
+# Maintainer: Dilawar Singh <dilawars@ncbs.res.in>
 # Created: Wed Jul 24 15:55:54 2013 (+0530)
+#
 # Notes: 
 #    For update/log, please see git-blame documentation or browse the github 
 #    repo https://github.com/BhallaLab/moose-core
-
-
-try:
-    from future_builtins import zip, map
-except ImportError as e:
-    pass
 
 import os
 import math
 import numpy as np
 import moose
-import logging
 
+import logging
 logger_ = logging.getLogger('moose.nml2')
 
 import neuroml         as nml
@@ -549,7 +545,10 @@ class NML2Reader(object):
         orig = chdens.id
         chid = moose.copy(proto_chan, comp, chdens.id)
         chan = moose.element(chid)
-        for p in self.paths_to_chan_elements.keys():
+
+        # We are updaing the keys() here. Need copy: using list(keys()) to
+        # create a copy.
+        for p in list(self.paths_to_chan_elements.keys()):
             pp = p.replace('%s/'%chdens.ion_channel,'%s/'%orig)
             self.paths_to_chan_elements[pp] = self.paths_to_chan_elements[p].replace('%s/'%chdens.ion_channel,'%s/'%orig)
         #logger_.info(self.paths_to_chan_elements)

--- a/scheduling/Clock.cpp
+++ b/scheduling/Clock.cpp
@@ -1027,8 +1027,8 @@ void Clock::buildDefaultTick()
     defaultDt_[16] = 0.1;
     defaultDt_[17] = 0.1;
     defaultDt_[18] = 1;             // For tables for chemical calculations.
-    defaultDt_[19] = 1;             // For Socket Streamer
-    defaultDt_[20] = 5;            // For CSV Streamer
+    defaultDt_[19] = 1;              // For Socket Streamer
+    defaultDt_[20] = 10;             // For CSV Streamer
 
     // 20-29 are not assigned.
     defaultDt_[30] = 1;    // For the HDF writer

--- a/shell/Neutral.cpp
+++ b/shell/Neutral.cpp
@@ -764,7 +764,6 @@ string Neutral::path( const Eref& e )
     stringstream ss;
 
     pathVec.push_back( curr );
-
     while ( curr.id != Id() )
     {
         ObjId mid = curr.eref().element()->findCaller( pafid );
@@ -777,10 +776,8 @@ string Neutral::path( const Eref& e )
         curr = Msg::getMsg( mid )->findOtherEnd( curr );
         pathVec.push_back( curr );
     }
-
     if ( pathVec.size() <= 1 )
         return "/";
-
     for ( unsigned int i = 1; i < pathVec.size(); ++i )
     {
         ss << "/";
@@ -795,7 +792,6 @@ string Neutral::path( const Eref& e )
         	ss << "[" << oid.dataIndex << "]";
         	*/
     }
-
     // Append braces if Eref was for a fieldElement. This should
     // work even if it is off-node.
     if ( e.element()->hasFields() )

--- a/shell/Neutral.cpp
+++ b/shell/Neutral.cpp
@@ -764,6 +764,7 @@ string Neutral::path( const Eref& e )
     stringstream ss;
 
     pathVec.push_back( curr );
+
     while ( curr.id != Id() )
     {
         ObjId mid = curr.eref().element()->findCaller( pafid );
@@ -776,8 +777,10 @@ string Neutral::path( const Eref& e )
         curr = Msg::getMsg( mid )->findOtherEnd( curr );
         pathVec.push_back( curr );
     }
+
     if ( pathVec.size() <= 1 )
         return "/";
+
     for ( unsigned int i = 1; i < pathVec.size(); ++i )
     {
         ss << "/";
@@ -792,6 +795,7 @@ string Neutral::path( const Eref& e )
         	ss << "[" << oid.dataIndex << "]";
         	*/
     }
+
     // Append braces if Eref was for a fieldElement. This should
     // work even if it is off-node.
     if ( e.element()->hasFields() )

--- a/shell/Wildcard.cpp
+++ b/shell/Wildcard.cpp
@@ -104,11 +104,6 @@ static int innerFind( const string& path, vector< ObjId >& ret)
     return wildcardRelativeFind( start, names, 0, ret );
 }
 
-/*
-static int wildcardRelativeFind( Id start, const vector< string >& path,
-		unsigned int depth, vector< Id >& ret )
-		*/
-
 /**
  * This is the basic wildcardFind function, working on a single
  * tree. It adds entries into the vector 'ret' with Ids found according

--- a/tests/py_moose/test_table_streaming_support.py
+++ b/tests/py_moose/test_table_streaming_support.py
@@ -27,8 +27,8 @@ def print_table( table ):
     msg += ' Path: %s' % table.path
     print( msg )
 
-def test( ):
-    compt = moose.CubeMesh( '/compt' )
+def test_small( ):
+    moose.CubeMesh( '/compt' )
     r = moose.Reac( '/compt/r' )
     a = moose.Pool( '/compt/a' )
     a.concInit = 1
@@ -69,10 +69,82 @@ def test( ):
     c = np.loadtxt( 'tablec.csv', skiprows=1 )
     assert (len(a) == len(b) == len(c))
 
-def main( ):
-    test( )
-    print( '[INFO] All tests passed' )
+def buildLargeSystem(useStreamer = False):
+    # create a huge system.
+    if moose.exists('/comptB'):
+        moose.delete('/comptB')
+    moose.CubeMesh( '/comptB' )
 
+    tables = []
+    for i in range(300):
+        r = moose.Reac('/comptB/r%d'%i)
+        a = moose.Pool('/comptB/a%d'%i)
+        a.concInit = 10.0
+        b = moose.Pool('/comptB/b%d'%i) 
+        b.concInit = 2.0
+        c = moose.Pool('/comptB/c%d'%i)
+        c.concInit = 0.5
+        moose.connect( r, 'sub', a, 'reac' )
+        moose.connect( r, 'prd', b, 'reac' )
+        moose.connect( r, 'prd', c, 'reac' )
+        r.Kf = 0.1
+        r.Kb = 0.01
+
+        # Make table name large enough such that the header is larger than 2^16
+        # . Numpy version 1 can't handle such a large header. If format 1 is
+        # then this test will fail.
+        t = moose.Table2('/comptB/TableO1%d'%i + 'abc'*100)
+        moose.connect(t, 'requestOut', a, 'getConc')
+        tables.append(t)
+
+    if useStreamer:
+        s = moose.Streamer('/comptB/streamer')
+        s.outfile = 'data2.npy'
+        print("[INFO ] Total tables %d" % len(tables))
+
+        # Add tables using wilcardFind.
+        s.addTables(moose.wildcardFind('/##[TYPE=Table2]'))
+
+        print("Streamer has %d table" % s.numTables)
+        assert s.numTables == len(tables)
+
+    moose.reinit()
+    moose.start(10)
+
+    if useStreamer:
+        # load the data
+        data = np.load(s.outfile)
+        header = str(data.dtype.names)
+        assert len(header) > 2**16
+    else:
+        data = { x.path : x.vector for x in tables }
+    return data
+
+def test_large_system():
+    # Get data without streamer and with streamer.
+    # These two must be the same.
+    X = buildLargeSystem(False)   # without streamer
+    Y = buildLargeSystem(True)    # with streamer.
+
+    # X has no time.
+    assert len(X) == len(Y.dtype.names)-1, (len(X), Y.dtype)
+
+    # same column names.
+    xNames = list(X.keys())
+    yNames = list(Y.dtype.names)
+    assert set(yNames) - set(xNames)  == set(['time'])
+
+    # Test for equality in some tables.
+    for i in range(1, 10):
+        a, b = Y[xNames[i]], X[xNames[i]]
+        assert a.shape == b.shape, (a.shape, b.shape)
+        assert (a == b).all(), (a-b)
+
+
+def main( ):
+    # test_small( )
+    test_large_system()
+    print( '[INFO] All tests passed' )
 
 if __name__ == '__main__':
     main()

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 include( ${CMAKE_CURRENT_SOURCE_DIR}/../CheckCXXCompiler.cmake)
 
-IF(WITH_BOOST)
-include(CheckIncludeFiles)
-check_include_files( ${Boost_INCLUDE_DIRS}/boost/random/random_device.hpp
-    BOOST_RANDOM_DEVICE_EXISTS
-    )
-endif(WITH_BOOST)
-
 add_library(utility
     strutil.cpp
     types.cpp
@@ -19,3 +12,12 @@ add_library(utility
     fileutils.cpp
     utility.cpp
     )
+
+add_executable(test_cnpy test_cnpy.cpp)
+target_link_libraries(test_cnpy utility)
+
+set(TEST_SCRIPT ${CMAKE_BINARY_DIR}/test_cnpy.py)
+file(WRITE ${TEST_SCRIPT} "import numpy as np")
+
+enable_testing()
+add_test(NAME cpp_test_cnpy COMMAND $<TARGET_FILE:test_cnpy>)

--- a/utility/cnpy.cpp
+++ b/utility/cnpy.cpp
@@ -17,48 +17,26 @@
  */
 
 #include "cnpy.hpp"
-#include <cstring>
+#include <fstream>
+#include <iterator>
+
 #include "print_function.hpp"
 
 using namespace std;
 
-namespace cnpy2 {
+namespace cnpy2
+{
 
 // Check the endian-ness of machine at run-time. This is from library
 // https://github.com/rogersce/cnpy
-char BigEndianTest() {
+char BigEndianTest()
+{
     unsigned char x[] = {1,0};
     short y = *(short*) x;
     return y == 1 ? '<' : '>';
 }
 
-// And another function to convert given std datatype to numpy representation.
-char map_type(const std::type_info& t)
-{
-    if(t == typeid(float) ) return 'f';
-    if(t == typeid(double) ) return 'd';
-    if(t == typeid(long double) ) return 'd';
-
-    if(t == typeid(int) ) return 'i';
-    if(t == typeid(char) ) return 'i';
-    if(t == typeid(short) ) return 'i';
-    if(t == typeid(long) ) return 'i';
-    if(t == typeid(long long) ) return 'i';
-
-    if(t == typeid(unsigned char) ) return 'u';
-    if(t == typeid(unsigned short) ) return 'u';
-    if(t == typeid(unsigned long) ) return 'u';
-    if(t == typeid(unsigned long long) ) return 'u';
-    if(t == typeid(unsigned int) ) return 'u';
-
-    if(t == typeid(bool) ) return 'b';
-
-    if(t == typeid(std::complex<float>) ) return 'c';
-    if(t == typeid(std::complex<double>) ) return 'c';
-    if(t == typeid(std::complex<long double>) ) return 'c';
-
-    else return '?';
-}
+size_t headerSize = 0;
 
 void split(vector<string>& strs, string& input, const string& pat)
 {
@@ -72,6 +50,26 @@ void split(vector<string>& strs, string& input, const string& pat)
     delete pch;
 }
 
+string shapeToString(const vector<size_t>& shape)
+{
+    string s{"("};
+    if(! shape.empty())
+    {
+        s += std::to_string(shape[0]);
+        for(size_t i = 1; i < shape.size(); i++)
+        {
+            s += ",";
+            s += std::to_string(shape[i]);
+        }
+        if(shape.size() == 1)
+            s += ",";
+    }
+    else
+        s += "0,";
+    s += ")";
+    return s;
+}
+
 /**
  * @brief Check if a numpy file is sane or not.
  *
@@ -81,18 +79,18 @@ void split(vector<string>& strs, string& input, const string& pat)
  *
  * @return  true if file is sane, else false.
  */
-bool is_valid_numpy_file( FILE* fp )
+bool isValidNumpyFile( FILE* fp )
 {
     assert( fp );
-    char buffer[__pre__size__];
-    size_t nr = fread( buffer, sizeof(char), __pre__size__, fp );
+    char buffer[__pre__.size()];
+    size_t nr = fread( buffer, sizeof(char), __pre__.size(), fp );
 
     if( 0 == nr )
         return false;
 
     bool equal = true;
     // Check for equality
-    for(size_t i = 0; i < __pre__size__; i++ )
+    for(size_t i = 0; i < __pre__.size(); i++ )
         if( buffer[i] != __pre__[i] )
         {
             equal = false;
@@ -106,18 +104,20 @@ bool is_valid_numpy_file( FILE* fp )
  *
  * @param header
  */
-void parse_header( FILE* fp, string& header )
+void findHeader(std::fstream& fs, string& header )
 {
     // Read header, till we hit newline character.
     char ch;
+    fs.seekg(0);                                 // Go to the begining.
     header.clear();
-    while( ( ch = fgetc( fp )) != EOF )
+    while(! fs.eof())
     {
+        fs.get(ch);
         if( '\n' == ch )
             break;
-        header.push_back( ch );
+        header.push_back(ch);
     }
-    assert( header.size() >= __pre__size__ );
+    assert( header.size() >= __pre__.size() );
 }
 
 /**
@@ -127,21 +127,13 @@ void parse_header( FILE* fp, string& header )
  * @param data_len
  * @param
  */
-void change_shape_in_header( const string& filename
-        , const size_t data_len, const size_t numcols
-        )
+void changeHeaderShape(std::fstream& fs, const size_t data_len, const size_t numcols)
 {
-    string header;
+    string header{""};
 
-    // Always open file in r+b mode. a+b mode always append at the end.
-    FILE* fp = fopen( filename.c_str(), "r+b" );
-    if( ! fp )
-    {
-        moose::showWarn( "Failed to open " + filename );
-        return;
-    }
-
-    parse_header( fp, header );
+    // Find header. Search for newline.
+    findHeader(fs, header);
+    const size_t headerSize = header.size();
 
     size_t shapePos = header.find( "'shape':" );
     size_t lbrac = header.find( '(', shapePos );
@@ -152,25 +144,181 @@ void change_shape_in_header( const string& filename
     string prefixHeader = header.substr( 0, lbrac + 1 );
     string postfixHeader = header.substr( rbrac );
 
-    string shapeStr = header.substr( lbrac + 1, rbrac - lbrac - 1);
+    string shapeStr = header.substr( lbrac+1, rbrac-lbrac-1);
 
     vector<string> tokens;
     split( tokens, shapeStr, "," );
 
     string newShape = "";
     for (size_t i = 0; i < tokens.size(); i++)
-        newShape += moose::toString( atoi( tokens[i].c_str() ) + data_len/numcols ) + ",";
+        newShape += std::to_string( atoi( tokens[i].c_str() ) + data_len/numcols ) + ",";
 
-    string newHeader = prefixHeader + newShape + postfixHeader + "\n";
+    string newHeader = prefixHeader + newShape + postfixHeader;
     if( newHeader.size() < header.size() )
     {
         cout << "Warn: Modified header can not be smaller than old header" << endl;
     }
 
-    // Move to at the begining of file and write the new header.
-    fseek(fp, 0, SEEK_SET);
-    fwrite( newHeader.c_str(), sizeof(char), newHeader.size(), fp );
-    fclose( fp );
+    // Resize to the old header size. Newline is not included in the header.
+    newHeader.resize(header.size());
+    newHeader += '\n';                          // Add newline before writing. 
+    fs.seekp(0);
+    fs.write(newHeader.c_str(), newHeader.size());
+}
+
+size_t writeHeader(std::fstream& fs, const vector<string>& colnames, const vector<size_t>& shape)
+{
+    // Heder are always at the begining of file.
+    fs.seekp(0);
+
+    // Write the format string. 8 bytes.
+    fs.write(&__pre__[0], __pre__.size());
+
+    char endianChar = cnpy2::BigEndianTest();
+    const char formatChar = 'd';
+
+    // Next 4 bytes are header length. This is computed again when data is
+    // appended to the file. We can have maximum of 2^32 bytes of header which
+    // ~4GB.
+
+    string header = ""; // This is the header to numpy file
+    header += "{'descr':[";
+    for( auto it = colnames.cbegin(); it != colnames.end(); it++ )
+        header += "('" + *it + "','" + endianChar + formatChar + "'),";
+
+    // shape is changed everytime we append the data. We use fixed number of
+    // character in shape. Its a int, we will use 13 chars to represent shape.
+    header += "], 'fortran_order':False,'shape':";
+    header += shapeToString(shape);
+    header += ",}";
+
+    // Add some extra sapce for safety.
+    header += string(12, ' ');
+
+    // FROM THE DOC: It is terminated by a newline (\n) and padded with spaces
+    // (\x20) to make the total of len(magic string) + 2 + len(length) +
+    // HEADER_LEN be evenly divisible by 64 for alignment purposes.
+    // pad with spaces so that preamble+headerlen+header is modulo 16 bytes.
+    // preamble is 8 bytes, header len is 4 bytes, total 12.
+    // header needs to end with \n
+    unsigned int remainder = 16 - (12 + header.size()) % 16;
+    header.insert(header.end(), remainder-1, ' ');
+    header += '\n';                             // Add newline. 
+
+    // Now write the size of header. Its 4 byte long in version 2.
+    uint32_t s = header.size();
+    fs.write((char*)&s, 4);
+    fs << header;
+    return fs.tellp();
+}
+
+
+size_t initNumpyFile(const string& outfile, const vector<string>& colnames)
+{
+    std::fstream fs;
+    fs.open(outfile, std::fstream::in | std::fstream::out | std::fstream::trunc | std::ofstream::binary);
+
+    if(! fs.is_open())
+    {
+        cerr << "Error: Could not create " << outfile << endl;
+        return 0;
+    }
+    vector<size_t> shape;
+    auto pos = writeHeader(fs, colnames, shape);
+    fs.close();
+    return pos;
+}
+
+void writeNumpy(const string& outfile, const vector<double>& data, const vector<string>& colnames)
+{
+
+    // In our application, we need to write a vector as matrix. We do not
+    // support the stacking of matrices.
+    vector<size_t> shape;
+
+    if( colnames.size() == 0)
+        return;
+
+    shape.push_back(data.size() / colnames.size());
+
+    // Create a new file.
+    std::fstream fs;
+    fs.open(outfile, std::ofstream::in | std::ofstream::out | std::ofstream::binary | std::ofstream::trunc);
+
+    /* In mode "w", open the file and write a header as well. When file is open
+     * in mode "a", we assume that file is alreay a valid numpy file.
+     */
+    if(! fs.is_open())
+    {
+        moose::showWarn( "Could not open file " + outfile );
+        return;
+    }
+
+    auto p = writeHeader( fs, colnames, shape );
+    fs.seekp(p);
+
+    // Here the previous character is '\n'
+
+    fs.write(reinterpret_cast<const char*>(data.data()), sizeof(double)*data.size());
+    fs.close();
+}
+
+void appendNumpy(const string& outfile, const vector<double>& vec, const vector<string>& colnames)
+{
+
+    std::fstream fs;
+    fs.open(outfile, std::fstream::in | std::fstream::out | std::fstream::binary);
+
+    if( ! fs.is_open() )
+    {
+        moose::showWarn( "Could not open " + outfile + " to write " );
+        return;
+    }
+
+    // And change the shape in header.
+    changeHeaderShape(fs, vec.size(), colnames.size());
+
+    // Go to the end.
+    fs.seekp(0, std::ios_base::end);
+    fs.write(reinterpret_cast<const char*>(&vec[0]), sizeof(double)*vec.size());
+    fs.close();
+}
+
+void readNumpy(const string& infile, vector<double>& data)
+{
+    cout << "Reading from " << infile << endl;
+    std::ifstream fs;
+    fs.open(infile, std::ios::in | std::ios::binary);
+
+    if(! fs.is_open())
+    {
+        cerr << "Could not open " << infile << endl;
+        return;
+    }
+
+    char ch;
+    fs.get(ch);
+    size_t nBytes = 1;
+    while(ch != '\n')
+    {
+        fs.get(ch);
+        nBytes += 1;
+    }
+
+    char buff[sizeof(double)];
+    double x;
+
+    fs.seekg(nBytes, std::ios_base::beg);
+    while(! fs.eof())
+    {
+        fs.read(buff, sizeof(double));
+        if(fs.gcount() != 8) 
+            break;
+        memcpy(&x, buff, sizeof(double));
+        data.push_back(x);
+    }
+    cout << endl;
+    fs.close();
 }
 
 }                                               /* Namespace cnpy2 ends. */

--- a/utility/cnpy.hpp
+++ b/utility/cnpy.hpp
@@ -28,31 +28,22 @@
 #include <complex>
 #include <typeinfo>
 
-#ifdef  ENABLE_CPP11
 #include <memory>
 #include <array>
-#else      /* -----  not ENABLE_CPP11  ----- */
-#endif     /* -----  not ENABLE_CPP11  ----- */
-
 #include <string>
-
 #include <stdint.h>
-
-#include "../basecode/global.h"
 
 #include "../utility/print_function.hpp"
 
 
 using namespace std;
 
-namespace cnpy2 {
+namespace cnpy2
+{
 
 // Check the endian-ness of machine at run-time. This is from library
 // https://github.com/rogersce/cnpy
 char BigEndianTest();
-
-// And another function to convert given std datatype to numpy representation.
-char map_type(const std::type_info& t);
 
 void split(vector<string>& strs, string& input, const string& pat);
 
@@ -65,14 +56,14 @@ void split(vector<string>& strs, string& input, const string& pat);
  *
  * @return  true if file is sane, else false.
  */
-bool is_valid_numpy_file( FILE* fp );
+bool isValidNumpyFile(std::ifstream& fp);
 
 /**
  * @brief Parser header from a numpy file. Store it in vector.
  *
  * @param header
  */
-void parse_header( FILE* fp, string& header );
+void findHeader(std::fstream& fp, string& header );
 
 /**
  * @brief Change shape in numpy header.
@@ -81,146 +72,43 @@ void parse_header( FILE* fp, string& header );
  * @param data_len
  * @param
  */
-void change_shape_in_header( const string& filename
-        , const size_t data_len, const size_t numcols
-        );
+void changeHeaderShape(std::ofstream& fs, const size_t data_len, const size_t numcols);
 
-static const unsigned int __pre__size__ = 8;
-static char __pre__[__pre__size__] = {
+// Use version 2.0 of npy fommat.
+// https://numpy.org/devdocs/reference/generated/numpy.lib.format.html
+static vector<char> __pre__ {
     (char)0x93, 'N', 'U', 'M', 'P', 'Y'         /* Magic */
-        , (char)0x01, (char) 0x00               /* format */
+    , (char)0x02, (char) 0x00               /* format */
 };
 
-template< typename T>
-void write_header(
-        FILE* fp
-        , const vector<string>& colnames
-        , vector<unsigned int>shape ,  char version
-        )
-{
-    // Heder are always at the begining of file.
-    fseek( fp, 0, SEEK_SET );
-    char endianChar = cnpy2::BigEndianTest();
-    char formatChar = cnpy2::map_type( typeid(T) );
+size_t writeHeader(std::fstream& fp, const vector<string>& colnames, const vector<size_t>& shape);
 
-    string dict = ""; // This is the header to numpy file
-    dict += "{'descr': [";
-    for( vector<string>::const_iterator it = colnames.begin();
-            it != colnames.end(); it++ )
-        dict += "('" + *it + "' , '" + endianChar + formatChar + "'),";
+void writeNumpy(const string& outfile, const vector<double>& vec, const vector<string>& colnames);
 
-    dict += "], 'fortran_order': False, 'shape': (";
-    dict += moose::toString(shape[0]);
-    for(size_t i = 1; i < shape.size(); i++)
-    {
-        dict += ",";
-        dict += moose::toString(shape[i]);
-    }
-    if( shape.size() == 1) dict += ",";
-    dict += "), }";
+void appendNumpy(const string& outfile, const vector<double>& vec, const vector<string>& colnames);
 
-    // When appending to this file, we need to rewrite header. Size of header
-    // might change since shape values might change. Minimum shape from (1,)
-    // could become quite large (13132131321,) etc. For safety region, append a
-    // chunk of whitespace characters so that overwriting header does not
-    // overwrite the data. This trick would save us from copying data into
-    // memory.
-    dict += string(11, ' ');                    /* 32 bit number is fit */
+/* --------------------------------------------------------------------------*/
+/**
+ * @Synopsis  initialize a numpy file with given column names.
+ *
+ * @Param filename
+ * @Param colnames
+ */
 
-    // pad with spaces so that preamble+headerlen+dict is modulo 16 bytes.
-    // preamble is 8 bytes, header len is 4 bytes, total 12.
-    // dict needs to end with \n
-    unsigned int remainder = 16 - (12 + dict.size()) % 16;
-    dict.insert(dict.end(),remainder,' ');
-    *(dict.end()-1) = '\n';
-
-    if( version == '2' )
-        __pre__[6] = (char) 0x02;
-
-    fwrite( __pre__, sizeof( char ), __pre__size__, fp );
-
-    // Now write the size of dict. It is 2bytes long in version 1 and 4 bytes
-    // long in version 2.
-    if( version == '2' )
-    {
-        uint32_t s = dict.size();
-        fwrite( (char*)&s, sizeof( uint32_t ), 1, fp );
-    }
-    else
-    {
-        int16_t s = dict.size();
-        fwrite( (char*)&s, sizeof( uint16_t ), 1, fp );
-    }
-    fwrite( dict.c_str(), sizeof(char), dict.size(), fp );
-}
-
-// write to version 1 or version 2.
-template<typename T>
-void save_numpy(
-        const string& outfile
-        , const vector<double>& vec
-        , vector<string> colnames
-        , const string openmode
-        , const char version = '1'
-        )
-{
-
-    // In our application, we need to write a vector as matrix. We do not
-    // support the stacking of matrices.
-    vector<unsigned int> shape;
-
-    if( colnames.size() == 0)
-        return;
-
-    shape.push_back( vec.size() / colnames.size());
-
-    /* In mode "w", open the file and write a header as well. When file is open
-     * in mode "a", we assume that file is alreay a valid numpy file.
-     */
-    if( openmode == "w" )
-    {
-        FILE* fp = fopen( outfile.c_str(), "wb" );
-        if( NULL == fp )
-        {
-            moose::showWarn( "Could not open file " + outfile );
-            return;
-        }
-        write_header<T>( fp, colnames, shape, version );
-        fclose( fp );
-    }
-    else                                        /* Append mode. */
-    {
-        // Do a sanity check if file is really a numpy file.
-        FILE* fp = fopen( outfile.c_str(), "r" );
-        if( ! fp )
-        {
-            moose::showError( "Can't open " + outfile + " to validate" );
-            return;
-        }
-        else if(! is_valid_numpy_file( fp ) )
-        {
-            moose::showWarn( outfile + " is not a valid numpy file"
-                    + " I am not goind to write to it"
-                    );
-            return;
-        }
-        if( fp )
-            fclose( fp );
-        // And change the shape in header.
-        change_shape_in_header( outfile, vec.size(), colnames.size() );
-    }
-
-    FILE* fp = fopen( outfile.c_str(), "ab" );
-    if( NULL == fp )
-    {
-        moose::showWarn( "Could not open " + outfile + " to write " );
-        return;
-    }
-    fwrite( &vec[0], sizeof(T), vec.size(), fp );
-    fclose( fp );
-
-}
+size_t initNumpyFile(const string& outfile, const vector<string>& colnames);
 
 
-}                                               /* Namespace cnpy2 ends. */
+/* --------------------------------------------------------------------------*/
+/**
+ * @Synopsis  read numpy file and return data in a vector. This for testing
+ * purpose and should not used to read data.
+ *
+ * @Param infile
+ * @Param data
+ */
+/* ----------------------------------------------------------------------------*/
+void readNumpy(const string& infile, vector<double>& data);
+
+} // Namespace cnpy2 ends.
+
 #endif   /* ----- #ifndef cnpy_INC  ----- */

--- a/utility/test_cnpy.cpp
+++ b/utility/test_cnpy.cpp
@@ -1,0 +1,64 @@
+// =====================================================================================
+//
+//       Filename:  test_cnpy.cpp
+//
+//    Description: Test cnpy. 
+//
+//        Version:  1.0
+//        Created:  Monday 09 March 2020 01:22:51  IST
+//       Revision:  none
+//       Compiler:  g++
+//
+//         Author:  Dilawar Singh (), dilawar.s.rajput@gmail.com
+//   Organization:  NCBS Bangalore
+//
+// =====================================================================================
+
+#include "cnpy.hpp"
+
+#include <vector>
+#include <cstdlib>
+
+using namespace std;
+
+
+int main(int argc, const char *argv[])
+{
+    srand(time(NULL));
+
+    string datafile = "_a_data.npy";
+    vector<string> cols {"A", "B", "C", "P", "Q" };
+
+    // Now append data.
+    vector<double> data;
+    for (size_t i = 0; i < cols.size(); i++) 
+        for (size_t ii = 0; ii < 10; ii++) 
+            data.push_back(rand() / (double)RAND_MAX);
+
+    cout << "Size of data is " << data.size() << endl;
+
+    cnpy2::writeNumpy(datafile, data, cols);
+    vector<double> r1;
+    cnpy2::readNumpy(datafile, r1);
+    cout << "Size of data without append: " << r1.size() << endl;
+    for (size_t i = 0; i < r1.size(); i++)
+        assert(r1[i] == data[i]);
+
+
+    datafile = "_b_data.npy";
+    cnpy2::initNumpyFile(datafile, cols);
+    cnpy2::appendNumpy(datafile, data, cols);
+    cnpy2::appendNumpy(datafile, data, cols);
+    cnpy2::appendNumpy(datafile, data, cols);
+
+    vector<double> r2;
+    cnpy2::readNumpy(datafile, r2);
+
+    cout << "Total data read " << r2.size() << endl;
+    assert(r2.size() == 3 * data.size() );
+
+    for (size_t i = 0; i < r2.size(); i++)
+        assert(data[i%data.size()] == r2[i]);
+    
+    return 0;
+}


### PR DESCRIPTION
Followup on #360 and #362 

- `moose.Streamer` now support `npy` format (version 2.0)
- Fixes a minor bug in `neuroml2` reader (related to python3 only).


