### PR TITLE
swc issues and moogList

### DIFF
--- a/python/rdesigneur/moogul.py
+++ b/python/rdesigneur/moogul.py
@@ -218,7 +218,7 @@ class MooDrawable:
 class MooNeuron( MooDrawable ):
     ''' Draws collection of line segments of defined dia and color'''
     def __init__( self,
-        neuronId,
+        mooObj,
         fieldInfo,
         field = 'Vm', 
         relativeObj = '.', 
@@ -235,12 +235,12 @@ class MooNeuron( MooDrawable ):
                 colormap = colormap, lenScale = lenScale, 
                 diaScale = diaScale, autoscale = autoscale, 
                 valMin = valMin, valMax = valMax )
-        self.neuronId = neuronId
+        self.mooObj = mooObj
         self.updateCoords()
 
     def updateCoords( self ):
         ''' Obtains coords from the associated cell'''
-        self.compts_ = moose.wildcardFind( self.neuronId.path + "/#[ISA=CompartmentBase]" )
+        self.compts_ = self.mooObj
         # Matplotlib3d isn't able to do full rotations about an y axis,
         # which is what the NeuroMorpho models use, so
         # here we shuffle the axes around. Should be an option.

--- a/python/rdesigneur/rdesigneur.py
+++ b/python/rdesigneur/rdesigneur.py
@@ -1229,10 +1229,10 @@ rdesigneur.rmoogli.updateMoogliViewer()
 
     def _loadElec( self, efile, elecname ):
         if ( efile[ len( efile ) - 2:] == ".p" ):
-            self.elecid = moose.loadModel( efile, '/library/' + elecname)[0]
+            self.elecid = moose.loadModel( efile, '/library/' + elecname)
             print(self.elecid)
         elif ( efile[ len( efile ) - 4:] == ".swc" ):
-            self.elecid = moose.loadModel( efile, '/library/' + elecname)[0]
+            self.elecid = moose.loadModel( efile, '/library/' + elecname)
         else:
             nm = NeuroML()
             print("in _loadElec, combineSegments = ", self.combineSegments)

--- a/python/rdesigneur/rdesigneur.py
+++ b/python/rdesigneur/rdesigneur.py
@@ -687,6 +687,56 @@ class rdesigneur:
         else:
             return comptList, kf[1]
 
+    # Returns vector of source objects, and the field to use. 
+    # Specifically for _buildMoogli() as there the coordinates of the compartments are needed.
+    # plotSpec is of the form
+    #   [ region_wildcard, region_expr, path, field, title]
+    def _MoogparseComptField( self, comptList, plotSpec, knownFields ):
+        # Put in stuff to go through fields if the target is a chem object
+        field = plotSpec.field
+        if not field in knownFields:
+            print("Warning: Rdesigneur::_parseComptField: Unknown field '{}'".format( field ) )
+            return (), ""
+
+        kf = knownFields[field] # Find the field to decide type.
+        # if kf[0] in ['CaConcBase', 'ChanBase', 'NMDAChan', 'VClamp']:
+        #     objList = self._collapseElistToPathAndClass( comptList, plotSpec.relpath, kf[0] )
+        #     return objList, kf[1]
+        if field in [ 'n', 'conc', 'volume']:
+            path = plotSpec.relpath
+            pos = path.find( '/' )
+            if pos == -1:   # Assume it is in the dend compartment.
+                path  = 'dend/' + path
+            pos = path.find( '/' )
+            chemCompt = path[:pos]
+            if chemCompt[-5:] == "_endo":
+                chemCompt = chemCompt[0:-5]
+            cc = moose.element( self.modelPath + '/chem/' + chemCompt)
+            voxelVec = []
+            temp = [ self._makeUniqueNameStr( i ) for i in comptList ]
+            #print( temp )
+            #print( "#####################" )
+            comptSet = set( temp )
+            #em = [ moose.element(i) for i in cc.elecComptMap ]
+            em = sorted( [ self._makeUniqueNameStr(i[0]) for i in cc.elecComptMap ] )
+            #print( em )
+            #print( "=================================================" )
+
+            voxelVec = [i for i in range(len( em ) ) if em[i] in comptSet ]
+            # Here we collapse the voxelVec into objects to plot.
+            allObj = moose.vec( self.modelPath + '/chem/' + plotSpec.relpath )
+            #print "####### allObj=", self.modelPath + '/chem/' + plotSpec[2]
+            if len( allObj ) >= len( voxelVec ):
+                objList = [ allObj[int(j)] for j in voxelVec]
+            else:
+                objList = []
+                print( "Warning: Rdesigneur::_parseComptField: unknown Object: '", plotSpec.relpath, "'" )
+            #print "############", chemCompt, len(objList), kf[1]
+            return objList, kf[1]
+
+        else:
+            return comptList, kf[1]
+
 
     def _buildPlots( self ):
         knownFields = {
@@ -769,8 +819,8 @@ class rdesigneur:
             pair = i.elecpath + " " + i.geom_expr
             dendCompts = self.elecid.compartmentsFromExpression[ pair ]
             spineCompts = self.elecid.spinesFromExpression[ pair ]
-            dendObj, mooField = self._parseComptField( dendCompts, i, knownFields )
-            spineObj, mooField2 = self._parseComptField( spineCompts, i, knownFields )
+            dendObj, mooField = self._MoogparseComptField( dendCompts, i, knownFields )
+            spineObj, mooField2 = self._MoogparseComptField( spineCompts, i, knownFields )
             assert( mooField == mooField2 )
             mooObj3 = dendObj + spineObj
             numMoogli = len( mooObj3 )

--- a/python/rdesigneur/rmoogli.py
+++ b/python/rdesigneur/rmoogli.py
@@ -39,7 +39,7 @@ def makeMoogli( rd, mooObj, args, fieldInfo ):
                 valMin = ymin, valMax = ymax )
         viewer.addDrawable( reacSystem )
     else:
-        neuron = moogul.MooNeuron( rd.elecid, fieldInfo,
+        neuron = moogul.MooNeuron( mooObj, fieldInfo,
                 field = mooField, relativeObj = relObjPath,
                 valMin = ymin, valMax = ymax )
         print( "min = {}, max = {}".format(ymin, ymax) )


### PR DESCRIPTION
The following changes allow moogli to plot only the needed compartments for elec display.

1. The 'MooNeuron' class in moogul.py now takes a list of compartments as input (mooObj) instead of Neuron id. In its updateCoords function, self._compts is now directly assigned to that given list of compartments.
2. In the makeMoogli function of rmoogli.py, the mooObj is passed directly to the moogul.MooNeuron in all cases. Previously, except for 'n' and 'conc', rd.elecid was being sent which was why the whole neuron was being plotted.
3. Finally, in rdesigneur.py, a new class _MoogparseComptField is made for collecting and making list of compartments specifically for _buildMoogli function. I did not want to touch the original _parseComptField function as it could have led to _buildPlots not working properly.

No change if the fields are 'n' or 'conc' ie they work as before. 
For the case of 'volume', the new code may not work ie havent checked, but should be quickly made to work by removing 'volume' from the 'if' statement in the new function '_MoogparseComptField()' in rdesgneur.py.
For all other possble inputs, it now plots only those compartments which are specified in the moogList field of rdesigneur.

Apart from this, the previous commit had a problem where if swc is used in cellProto, it gave a 'TypeError: 'moose._moose.ObjId' object is not subscriptable' error. Fixed that.

Have tested on all rdesigneur tutorial examples and it works without any errors.