### PR TITLE
Typo and partial fixes to Issue 426

### DIFF
--- a/ksolve/Stoich.cpp
+++ b/ksolve/Stoich.cpp
@@ -328,13 +328,15 @@ void Stoich::setElist(const Eref& e, const vector<ObjId>& elist)
 {
     if(compartment_ == Id()) {
         cerr << "Warning: Stoich::setElist/setReacSystemPath: Compartment not "
-                "set. Aborting." << endl;
+                "set. Aborting."
+             << endl;
         status_ = 4;
         return;
     }
     if(!(kinterface_ || dinterface_)) {
         cerr << "Warning: Stoich::setElist/setReacSystemPath: Neither solver "
-                "has been set. Aborting." << endl;
+                "has been set. Aborting."
+             << endl;
         status_ = 8;
         return;
     }
@@ -346,8 +348,10 @@ void Stoich::setElist(const Eref& e, const vector<ObjId>& elist)
     vector<Id> temp;
     filterWildcards(temp, elist);
     if(temp.size() == 0) {
-        cerr << "Warning: Stoich::setElist/setReacSystemPath: No kinetics objects "
-                "found on path. Aborting." << endl;
+        cerr << "Warning: Stoich::setElist/setReacSystemPath: No kinetics "
+                "objects "
+                "found on path. Aborting."
+             << endl;
         status_ = 16;
         return;
     }

--- a/ksolve/Stoich.cpp
+++ b/ksolve/Stoich.cpp
@@ -278,7 +278,7 @@ bool Stoich::getAllowNegative() const
 
 void Stoich::setPath(const Eref& e, string v)
 {
-    cout << "DeprecationWarning:: Use Soitch::readSystemPath instead. In "
+    cout << "DeprecationWarning:: Use Soitch::reacSystemPath instead. In "
             "the future, it will be an error."
          << endl;
     setReacSystemPath(e, v);

--- a/pybind11/helper.cpp
+++ b/pybind11/helper.cpp
@@ -400,37 +400,41 @@ vector<string> mooseGetFieldNames(const string& className,
         return ret;
     }
 
-    if(finfoType == "valueFinfo" || finfoType == "value") {
+    if(finfoType == "valueFinfo" || finfoType == "value" || finfoType == "*") {
         for(unsigned int ii = 0; ii < cinfo->getNumValueFinfo(); ++ii) {
             Finfo* finfo = cinfo->getValueFinfo(ii);
             ret.push_back(finfo->name());
         }
     }
-    else if(finfoType == "srcFinfo" || finfoType == "src") {
+    else if(finfoType == "srcFinfo" || finfoType == "src" || finfoType == "*") {
         for(unsigned int ii = 0; ii < cinfo->getNumSrcFinfo(); ++ii) {
             Finfo* finfo = cinfo->getSrcFinfo(ii);
             ret.push_back(finfo->name());
         }
     }
-    else if(finfoType == "destFinfo" || finfoType == "dest") {
+    else if(finfoType == "destFinfo" || finfoType == "dest" ||
+            finfoType == "*") {
         for(unsigned int ii = 0; ii < cinfo->getNumDestFinfo(); ++ii) {
             Finfo* finfo = cinfo->getDestFinfo(ii);
             ret.push_back(finfo->name());
         }
     }
-    else if(finfoType == "lookupFinfo" || finfoType == "lookup") {
+    else if(finfoType == "lookupFinfo" || finfoType == "lookup" ||
+            finfoType == "*") {
         for(unsigned int ii = 0; ii < cinfo->getNumLookupFinfo(); ++ii) {
             Finfo* finfo = cinfo->getLookupFinfo(ii);
             ret.push_back(finfo->name());
         }
     }
-    else if(finfoType == "sharedFinfo" || finfoType == "shared") {
+    else if(finfoType == "sharedFinfo" || finfoType == "shared" ||
+            finfoType == "*") {
         for(unsigned int ii = 0; ii < cinfo->getNumSrcFinfo(); ++ii) {
             Finfo* finfo = cinfo->getSrcFinfo(ii);
             ret.push_back(finfo->name());
         }
     }
-    else if(finfoType == "fieldElementFinfo" || finfoType == "fieldElement") {
+    else if(finfoType == "fieldElementFinfo" || finfoType == "fieldElement" ||
+            finfoType == "*") {
         for(unsigned int ii = 0; ii < cinfo->getNumFieldElementFinfo(); ++ii) {
             Finfo* finfo = cinfo->getFieldElementFinfo(ii);
             ret.push_back(finfo->name());
@@ -545,7 +549,6 @@ string mooseDoc(const string& query)
     throw runtime_error(__func__ + string(":: Not supported '" + query + "'"));
 }
 
-
 vector<string> mooseLe(const ObjId& obj)
 {
     vector<Id> children;
@@ -557,7 +560,7 @@ vector<string> mooseLe(const ObjId& obj)
     Neutral::children(obj.eref(), children);
     stringstream ss;
     ss << "Elements under " << obj.path() << endl;
-    for(auto ch: children) {
+    for(auto ch : children) {
         ss << "    " + ch.path() << endl;
         chPaths.push_back(ch.path());
     }
@@ -571,7 +574,7 @@ vector<ObjId> mooseListMsg(const ObjId& obj)
     auto inmsgs = Field<vector<ObjId>>::get(obj, "msgIn");
     for(const auto inobj : inmsgs) {
         const Msg* msg = Msg::getMsg(inobj);
-        if(! msg) {
+        if(!msg) {
             cerr << "No Msg found on " << obj.path() << endl;
             continue;
         }
@@ -592,28 +595,28 @@ string mooseShowMsg(const ObjId& obj)
     auto inmsgs = Field<vector<ObjId>>::get(obj, "msgIn");
     for(const auto inobj : inmsgs) {
         const Msg* msg = Msg::getMsg(inobj);
-        if(! msg) {
+        if(!msg) {
             cerr << "No Msg found on " << obj.path() << endl;
             continue;
         }
-        ss << fmt::format("  {0}, [{1}] <-- {2}, [{3}]\n", msg->getE2().path() 
-                , moose::vectorToCSV<string>(msg->getDestFieldsOnE2())
-                , msg->getE1().path() 
-                , moose::vectorToCSV<string>(msg->getSrcFieldsOnE1()));
+        ss << fmt::format("  {0}, [{1}] <-- {2}, [{3}]\n", msg->getE2().path(),
+                          moose::vectorToCSV<string>(msg->getDestFieldsOnE2()),
+                          msg->getE1().path(),
+                          moose::vectorToCSV<string>(msg->getSrcFieldsOnE1()));
     }
     ss << endl;
     auto outmsgs = Field<vector<ObjId>>::get(obj, "msgOut");
     ss << "OUTGOING:" << endl;
     for(const auto outobj : outmsgs) {
         const Msg* msg = Msg::getMsg(outobj);
-        if(! msg) {
+        if(!msg) {
             cerr << "No Msg found on " << obj.path() << endl;
             continue;
         }
-        ss << fmt::format("  {0}, [{1}] <-- {2}, [{3}]\n", msg->getE1().path() 
-                , moose::vectorToCSV<string>(msg->getSrcFieldsOnE1())
-                , msg->getE2().path() 
-                , moose::vectorToCSV<string>(msg->getDestFieldsOnE2()));
+        ss << fmt::format("  {0}, [{1}] <-- {2}, [{3}]\n", msg->getE1().path(),
+                          moose::vectorToCSV<string>(msg->getSrcFieldsOnE1()),
+                          msg->getE2().path(),
+                          moose::vectorToCSV<string>(msg->getDestFieldsOnE2()));
     }
     return ss.str();
 }

--- a/pybind11/pymoose.cpp
+++ b/pybind11/pymoose.cpp
@@ -280,6 +280,14 @@ PYBIND11_MODULE(_moose, m)
                                [](ObjId &oid) { return oid.dataIndex; })
         .def("getDataIndex", [](const ObjId &oid) { return oid.dataIndex; })
 
+        .def(
+            "getFieldNames",
+            [](const ObjId &oid, const string &fieldtype) {
+                return mooseGetFieldNames(oid.element()->cinfo()->name(),
+                                          fieldtype);
+            },
+            "fieldtype"_a = "*")
+
         .def_property_readonly("fieldIndex",
                                [](ObjId &oid) { return oid.fieldIndex; })
 
@@ -384,8 +392,9 @@ PYBIND11_MODULE(_moose, m)
      */
 
     m.def("seed", [](py::object &a) { moose::mtseed(a.cast<int>()); });
-    m.def("rand", [](double a, double b) { return moose::mtrand(a, b); },
-          "a"_a = 0, "b"_a = 1);
+    m.def(
+        "rand", [](double a, double b) { return moose::mtrand(a, b); },
+        "a"_a = 0, "b"_a = 1);
     // This is a wrapper to Shell::wildcardFind. The python interface must
     // override it.
     m.def("wildcardFind", &wildcardFind2);

--- a/python/moose/__init__.py
+++ b/python/moose/__init__.py
@@ -284,7 +284,7 @@ def getFieldDict(classname, finfoType=""):
     Returns
     -------
     dict
-        field names and their types.
+        field names and their respective types as key-value pair. 
 
     Notes
     -----
@@ -301,27 +301,29 @@ def getFieldDict(classname, finfoType=""):
     return _moose.getFieldDict(classname, finfoType)
 
 
-def getFieldNames(classname, fieldtype="*"):
-    """Get a tuple containing the name of all the fields of `finfoType` kind.
+def getFieldNames(elem, fieldtype="*"):
+    """Get a tuple containing name of fields of a given fieldtype. If
+    fieldtype is set to '*', all fields are returned.
 
     Parameters
     ----------
-    className : string
-        Name of the class to look up.
-    finfoType : string
-        The kind of field
-        -  valueFinfo
-        -  srcFinfo
-        -  destFinfo
-        -  lookupFinfo
-        -  fieldElementFinfo
+    elem : string, obj
+        Name of the class or a moose.element to look up.
+    fieldtype : string
+        The kind of field. Possible values are:
+        -  'valueFinfo' or 'value'
+        -  'srcFinfo' or 'src'
+        -  'destFinfo' or 'dest'
+        -  'lookupFinfo' or 'lookup'
+        -  'fieldElementFinfo' or 'fieldElement'
 
     Returns
     -------
     list
         Names of the fields of type `finfoType` in class `className`.
     """
-    return _moose.getFieldNames(classname, fieldtype)
+    clsname = elem if isinstance(elem, str) else elem.className
+    return _moose.getFieldNames(clsname, fieldtype)
 
 
 def isRunning():

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -45,6 +45,13 @@ def test_other():
     p.delay[1] = 0.99
     assert p.delay[1] == 0.99, p.delay[1]
 
+    c = moose.Stoich('/dadaa')
+    v1 = moose.getFieldNames(c)
+    v2 = c.getFieldNames()
+    assert v1 == v2
+    assert len(v1) > 10, v1
+    
+
 
 def test_vec():
     a = moose.Pool('/p111', 100)
@@ -126,6 +133,7 @@ def test_inheritance():
     assert isinstance(aa, moose.CubeMesh), (a.__class__, aa.__class__)
 
     a = moose.CubeMesh('yapf')
+    assert a.isA('CubeMesh') == a.isA['CubeMesh']
     assert a.isA['CubeMesh']
     assert a.isA['ChemCompt']
 


### PR DESCRIPTION
- Fixes typo #426 
- `getFieldNames` also available on the moose element. For example:

```python
>>> a = moose.Stoich('a')
>>> moose.getFieldNames(a)    # available before
>>> a.getFieldNames()               # added in this PR
```