### PR TITLE
Fixes to #429

### DIFF
--- a/pybind11/helper.h
+++ b/pybind11/helper.h
@@ -176,6 +176,9 @@ inline bool mooseDeleteObj(const ObjId& oid)
 
 inline bool mooseDeleteStr(const string& path)
 {
+    auto o = ObjId(path);
+    if(o.bad())
+        throw pybind11::value_error("Path '" + path + "' does not exists.");
     return getShellPtr()->doDelete(ObjId(path));
 }
 

--- a/python/moose/__init__.py
+++ b/python/moose/__init__.py
@@ -216,9 +216,7 @@ def connect(src, srcfield, dest, destfield, msgtype="Single"):
 
 
 def delete(arg):
-    """Delete the underlying moose object(s). This does not delete any of the
-    Python objects referring to this vec but does invalidate them. Any
-    attempt to access them will raise a ValueError.
+    """Delete the underlying moose object(s). 
 
     Parameters
     ----------
@@ -227,7 +225,7 @@ def delete(arg):
 
     Returns
     -------
-    None
+    None, Raises ValueError if given path/object does not exists.
     """
     _moose.delete(arg)
 


### PR DESCRIPTION
This fixes #429. If a user try to delete a non-existent path, moose raises a `ValueError` exception.