### PR TITLE
__version__ was mapped to a lambda

### DIFF
--- a/python/moose/__init__.py
+++ b/python/moose/__init__.py
@@ -73,12 +73,11 @@ for p in _moose.wildcardFind("/##[TYPE=Cinfo]"):
 # class types to _moose.
 from moose._moose import *
 
-
 def version():
     """Reutrns moose version string."""
     return _moose.__version__
 
-__version__ = lambda: version()
+__version__ = version()
 
 def version_info():
     """Return detailed version information.


### PR DESCRIPTION
`moose.__version__` was mapped to a function call. Now `moose.__version__` returns the output of `moose.version()` rather than a function object. 