### PR TITLE
Cleanup sbml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.9.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.2.3 FATAL_ERROR)
 
 # Project to build MOOSE's python module.
 project(PyMOOSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 4.9.3 FATAL_ERROR)
 
 # Project to build MOOSE's python module.
 project(PyMOOSE)
@@ -103,6 +103,25 @@ endif()
 if(WITH_BOOST OR WITH_BOOST_ODE)
     set(WITH_BOOST_ODE ON)
     set(WITH_GSL OFF)
+endif()
+
+find_package(HDF5 COMPONENTS CXX HL)
+
+if (NOT HDF5_FOUND)
+        message("==================================================================\n"
+            " HDF5 not found. Disabling NSDF support.\n\n"
+            " If you need NSDF support, please install hdf5-dev or hdf5-devel\n"
+            " package or equivalent.\n\n"
+            "     $ sudo apt-get install libhdf5-dev \n"
+            "     $ sudo yum install libhdf5-devel \n"
+            "     $ brew install hdf5 \n\n"
+            " Otherwise, continue with 'make' and 'make install' \n"
+            " If you install hdf5 to non-standard path, export environment \n"
+            " variable HDF5_ROOT to the location. Rerun cmake \n"
+            "================================================================ \n"
+	)
+elseif(HDF5_FOUND)
+	set(WITH_NSDF ON)
 endif()
 
 ################################### TARGETS ####################################

--- a/CheckCXXCompiler.cmake
+++ b/CheckCXXCompiler.cmake
@@ -20,8 +20,8 @@ add_definitions(-Wall
     )
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
-        message(FATAL_ERROR "Insufficient gcc version. Minimum requried 4.9")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.1")
+        message(FATAL_ERROR "Insufficient gcc version. Minimum requried 5.1")
     endif()
     add_definitions( -Wno-unused-local-typedefs )
     add_definitions( -fmax-errors=5 )

--- a/python/moose/SBML/readSBML.py
+++ b/python/moose/SBML/readSBML.py
@@ -517,7 +517,7 @@ def getCmptAnnotation(obj):
                         annotateMap[nodeName] = nodeValue
                     if nodeName == "surround":
                         annotateMap[nodeName] = nodeValue
-                    if nodeName == "basepath":
+                    if nodeName == "basePath":
                         annotateMap[nodeName] = nodeValue
     return annotateMap
 
@@ -1492,8 +1492,8 @@ def createCompartment(basePath, model, comptSbmlidMooseIdMap):
                 name = sbmlCmptId
             cmptAnnotaInfo = {}
             cmptAnnotaInfo = getCmptAnnotation(compt)
-            if "basepath" in cmptAnnotaInfo.keys():
-                nl = list(filter(None, (cmptAnnotaInfo["basepath"]).split('/')))
+            if "basePath" in cmptAnnotaInfo.keys():
+                nl = list(filter(None, (cmptAnnotaInfo["basePath"]).split('/')))
                 pathAnno = ""
                 if len(nl) > 0:
                     for i in range(0,len(nl)):

--- a/python/moose/SBML/writeSBML.py
+++ b/python/moose/SBML/writeSBML.py
@@ -13,10 +13,12 @@ r'''
 **           copyright (C) 2003-2017 Upinder S. Bhalla. and NCBS
 Created : Friday May 27 12:19:00 2016(+0530)
 Version
-Last-Updated: Tue 08 Sep 02:22:10 2020(+0530)
+Last-Updated: Tue 05 Apr 11:22:10 2022(+0530)
           By: HarshaRani
 **********************************************************************/
 /****************************
+2022
+Apr 5 : Added basepath in compartment Annotation
 2021
 Apr 16: replace ReacBase to Reac and EnzBase to Enz as API can has changed
 2020
@@ -541,7 +543,6 @@ def writeEnz(modelpath, cremodel_, sceneitems,groupInfo):
                             enzAnno2 = enzAnno2 +"<moose:enzyme>" + \
                                 (str(idBeginWith(convertSpecialChar(
                                 nameList_[i])))) + "</moose:enzyme>\n"
-
                         enzPrd = enz.neighbors["prd"]
                         noofPrd = len(enzPrd)
                         if not enzPrd:
@@ -1242,6 +1243,12 @@ def writeCompt(modelpath, cremodel_):
                                 str(compt.dataIndex) +
                                 "_")))
         comptID_sbml[compt] = csetId
+        nl = list(filter(None, (compt.parent.path).split('/')))
+        pathAnno = ""
+        if len(nl) > 1:
+            for i in range(1,len(nl)):
+                pathAnno = pathAnno+'/'+nl[i]
+            
         if compt.isA("EndoMesh"):
             if comptID_sbml.get(compt.surround) == None:
                 createCompt = False
@@ -1253,7 +1260,10 @@ def writeCompt(modelpath, cremodel_):
                                     "<moose:surround>" + \
                                     str(comptID_sbml[compt.surround])+ "</moose:surround>\n" + \
                                     "<moose:isMembraneBound>" + \
-                                    str(compt.isMembraneBound)+ "</moose:isMembraneBound>\n" 
+                                    str(compt.isMembraneBound)+ "</moose:isMembraneBound>\n"
+                if pathAnno != "":
+                    comptAnno = comptAnno + "<moose:basePath>" \
+                        + pathAnno + "</moose:basePath>"
                 if moose.exists(compt.path+'/info'):
                     if moose.element(compt.path+'/info').notes != "":
                         comptAnno = comptAnno + "<moose:Notes>" \
@@ -1269,6 +1279,10 @@ def writeCompt(modelpath, cremodel_):
                                 str(compt.diffLength)+ "</moose:diffLength>\n" + \
                                 "<moose:isMembraneBound>" + \
                                 str(compt.isMembraneBound)+ "</moose:isMembraneBound>\n"
+            if pathAnno != "":
+                    comptAnno = comptAnno + "<moose:basePath>" \
+                        + pathAnno + "</moose:basePath>"
+
             if moose.exists(compt.path+'/info'):
                 if moose.element(compt.path+'/info').notes != "":
                     comptAnno = comptAnno + "<moose:Notes>" \
@@ -1279,6 +1293,10 @@ def writeCompt(modelpath, cremodel_):
                                 str(compt.className) + "</moose:Mesh>\n" + \
                                 "<moose:isMembraneBound>" + \
                                 str(compt.isMembraneBound)+ "</moose:isMembraneBound>\n" 
+            if pathAnno != "":
+                    comptAnno = comptAnno + "<moose:basePath>" \
+                        + pathAnno + "</moose:basePath>"
+
             if moose.exists(compt.path+'/info'):
                 if moose.element(compt.path+'/info').notes != "":
                     comptAnno = comptAnno + "<moose:Notes>" \


### PR DESCRIPTION
Edge cases for with the model 
 - NN_mapk15.g which has extra Neutral path before compartment is taken care while writing and reading into SBML
 - OSC_different_vols 
         -- where pool being a parent and product, Stoichiometry need to reduce while reading the model
         -- function expression fixed if multiple of same pool exist
These changes made rdesignuer examples to work with SBML files and gives out the same result when passed genesis file
Corrected cmake version to 3.1 which was checked for 4.9