### PR TITLE
Fixed pybind11 includes and installation instructions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,9 @@ include(CheckCXXCompiler.cmake)
 include(CheckIncludeFileCXX)
 
 # We find python executable here. Though mainly used inside pymoose. 
-# FIXME: When cmake 3.12 is widely available use the following:
-#   find_package(Python3 COMPONENTS Interpreter Numpy)
-#   set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
-set(Python_ADDITIONAL_VERSIONS 2.7)
-find_package(PythonInterp 3.5)
-if(NOT PYTHONINTERP_FOUND)
-  find_package(PythonInterp 2.7)
-endif()
+find_package(Python3 COMPONENTS Interpreter Numpy)
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+find_package(PythonInterp 3.8)
 
 set(CMAKE_MACOSX_RPATH OFF)
 
@@ -321,14 +316,8 @@ endif( WITH_BOOST )
 # It can be easily done with `pip install pybind11`
 # See: https://pybind11.readthedocs.io/en/stable/installing.html
 # - Subha, Mon Apr 22 14:26:58 IST 2024
-
-# if(NOT WITH_LEGACY_BINDING)
-#     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/pybind11)
-#     add_subdirectory(pybind11)
-# else()
-#     message(STATUS "Building legacy python binding.")
-#     add_subdirectory(pymoose)
-# endif()
+find_package(pybind11 REQUIRED)
+add_subdirectory(pybind11)
 
 
 # always override debian default installation directory. It will be installed in

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,11 +8,12 @@ followings are installed.
 
 - gsl-1.16 or higher.
 - python-numpy
+- pybind11 (if the setup fails to find pybind11, try running `pip install pybind11[global]`)
 
 On Ubuntu-16.04 or higher, these dependencies can be installed with:
 
 ```
-sudo apt-get install python-pip python-numpy cmake libgsl-dev g++
+sudo apt-get install python-pip python-numpy cmake libgsl-dev g++ pybind11
 ```
 
 Now use `pip` to download and install `pymoose` from the [github repository](https://github.com/BhallaLab/moose-core).
@@ -83,10 +84,26 @@ Now you can import moose in a Python script or interpreter with the statement:
     >>> import moose
     >>> moose.test()   # will take time. Not all tests will pass.
 
+## Uninstall
+
+To uninstall moose, run
+
+    $ pip uninstall pymoose
+    
+If you are building moose from source, make sure to get out of the source directory, or you may encounter a message like this:
+
+    Found existing installation: pymoose {version}
+    Can't uninstall 'pymoose'. No files were found to uninstall.
+
+
+
+
 # Notes
 
-SBML support is enabled by installing
+- SBML support is enabled by installing
 [python-libsbml](http://sbml.org/Software/libSBML/docs/python-api/libsbml-installation.html).
 Alternatively, it can be installed by using `python-pip`
 
     $ sudo pip install python-libsbml
+
+

--- a/pybind11/Finfo.cpp
+++ b/pybind11/Finfo.cpp
@@ -9,10 +9,10 @@
 //
 // =====================================================================================
 
-#include "../external/pybind11/include/pybind11/pybind11.h"
-#include "../external/pybind11/include/pybind11/stl.h"
-#include "../external/pybind11/include/pybind11/numpy.h"
-#include "../external/pybind11/include/pybind11/functional.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+#include <pybind11/functional.h>
 
 namespace py = pybind11;
 

--- a/pybind11/MooseVec.cpp
+++ b/pybind11/MooseVec.cpp
@@ -13,9 +13,9 @@
 
 using namespace std;
 
-#include "../external/pybind11/include/pybind11/pybind11.h"
-#include "../external/pybind11/include/pybind11/numpy.h"
-#include "../external/pybind11/include/pybind11/stl.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 

--- a/pybind11/MooseVec.h
+++ b/pybind11/MooseVec.h
@@ -10,8 +10,8 @@
 #ifndef MOOSE_VEC_H
 #define MOOSE_VEC_H
 
-#include "../external/pybind11/include/pybind11/pybind11.h"
-#include "../external/pybind11/include/pybind11/numpy.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
 namespace py = pybind11;
 
 class MooseVec

--- a/pybind11/helper.cpp
+++ b/pybind11/helper.cpp
@@ -18,16 +18,16 @@
 #include <stdexcept>
 #include <csignal>
 
-#include "../external/pybind11/include/pybind11/functional.h"
-#include "../external/pybind11/include/pybind11/numpy.h"
-#include "../external/pybind11/include/pybind11/pybind11.h"
-#include "../external/pybind11/include/pybind11/stl.h"
+#include <pybind11/functional.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
 // See
 // https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#binding-stl-containers
-// #include "../external/pybind11/include/pybind11/stl_bind.h"
+// #include <pybind11/stl_bind.h>
 
 #include "../basecode/header.h"
 #include "../basecode/global.h"

--- a/pybind11/pymoose.cpp
+++ b/pybind11/pymoose.cpp
@@ -19,9 +19,9 @@
 #include <functional>
 #include <chrono>
 
-#include "../external/pybind11/include/pybind11/pybind11.h"
-#include "../external/pybind11/include/pybind11/stl.h"
-#include "../external/pybind11/include/pybind11/numpy.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
 
 namespace py = pybind11;
 using namespace std;


### PR DESCRIPTION
- main cmake file updated to look for pybind11 and build the pybind11 directory
- pybind11 includes fixed in `pybind11` subdirectory
- INSTALL.md updated with information on pybind11 requirements
- setup.py cleaned up to remove workaround for Python 2 and to improve naming