### PR TITLE
Execute the module to access the funtion in its namespace

### DIFF
--- a/python/rdesigneur/rdesigneur.py
+++ b/python/rdesigneur/rdesigneur.py
@@ -327,6 +327,7 @@ print( "Wall Clock Time = {:8.2f}, simtime = {:8.3f}".format( time.time() - _sta
             try:
                 # module = imp.load_module(moduleName, moduleFile, pathName, description)
                 module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
                 funcObj = getattr(module, funcName)
                 funcObj(protoName)
                 return True


### PR DESCRIPTION
Without the line, the funcName does not show up in the module's namespace and the funcName function cannot be executed in the next line.